### PR TITLE
fix: harden telegram archive reliability

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -39,6 +39,10 @@ GeekShare Archive 将 Telegram 频道的新推送、编辑、反应和媒体持�
 - 有来源消息或展示消息关联的频道不可删除，只能停用。
 - 站点品牌和 SEO 配置保存在 D1，站点图片保存在 R2，由 Worker 在请求时读取和注入，无需重新构建。
 - Webhook 先持久化正文和原始 Update，再异步归档媒体；媒体失败不能导致正文丢失。
+- Webhook `update_id` 只表示 delivery；`processing` 使用 10 分钟 lease，过期 delivery 可以原子 reclaim，完成态和新鲜 processing 的重复 delivery 不重复执行。
+- Telegram 消息使用 `(origin_channel_id, telegram_message_id)` 作为来源身份，`messages.id` 作为稳定公共归档身份；已有公共 ID 不因同步算法变化而重命名。
+- 媒体自动恢复采用 1、2、4、8 小时退避并在第 5 次失败后停止；人工重试可以重置 exhausted 状态。
+- thumbnail 失败必须可观察并可补偿，已成功的主 R2 对象继续复用；当前不支持的大型文件类型以明确的永久失败结束，不能无限请求。
 - 数据模型、公共消息结构和消息卡片支持多附件展示；Webhook 对每个 Telegram Update 仍只选择一种主媒体，尚未合并 media group 相册消息。
 - 精确 `/admin` 只展示不含管理 UI 的品牌登录入口；后台页面和管理接口依赖 Cloudflare Access，Worker 验证 Access JWT，写操作额外校验同源 `Origin`。
 - 管理员可以编辑正文、标签、展示频道、发布时间和发布状态；后台覆盖优先于后续 Telegram 编辑。
@@ -60,6 +64,7 @@ GeekShare Archive 将 Telegram 频道的新推送、编辑、反应和媒体持�
 - 2026-08-24 本地执行的 32 项测试、lint、typecheck、build、Assets 校验和 Wrangler dry-run 均通过。
 - 同日本地 D1 已应用 `0001`、`0002` 和 `0003` 三份 migration，包含 1 个演示频道和 10 条演示消息。
 - 2026-08-27 隔离 Local D1 回归测试验证同一份 10 条消息的快照连续导入后，`messages` 与 `messages_fts` 均保持 10 行且无重复 ID；`0004_rebuild_messages_fts.sql` 也将人为保留的 10 条消息 / 20 条 FTS 脏数据恢复为一一对应。
+- 2026-08-28 本地 57 项测试验证 Webhook lease/reclaim、跨频道消息身份、reaction 延迟重试、管理员覆盖、FTS 重放、媒体退避/耗尽、thumbnail 补偿以及 `0005` fresh/upgrade migration；同日 lint、typecheck、build、Assets 校验和 Wrangler dry-run 通过。
 
 上述证据证明仓库实现和本地构建状态，不证明远程 Cloudflare 资源、Webhook、Access、DNS、TLS 或生产数据当前健康。
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ npm run dev
 
 `npm run dev` 会构建静态站点并启动 Wrangler，使页面与 `/api/*` 使用同一服务。只调试静态 UI 时运行 `npm run dev:ui`；它不提供 Worker API、D1 或 R2。
 
-对同一份演示快照重复执行 `npm run db:import-d1:local` 是幂等的：消息会按 archive ID 更新，FTS 索引保持每条消息一行。`0004_rebuild_messages_fts.sql` 会在应用 migration 时从 `messages` 重建已有 FTS 索引。
+对同一份演示快照重复执行 `npm run db:import-d1:local` 是幂等的：消息会按 archive ID 更新，FTS 索引保持每条消息一行。`0004_rebuild_messages_fts.sql` 会在应用 migration 时从 `messages` 重建已有 FTS 索引；`0005_webhook_media_reliability.sql` 为 Webhook lease 和有界媒体重试增加状态字段，不重命名现有消息 ID。
 
 ## Cloudflare 配置与部署
 
@@ -131,6 +131,13 @@ $env:TELEGRAM_BOT_TOKEN = "replace-me"
 $env:TELEGRAM_WEBHOOK_SECRET = "replace-with-a-long-random-value"
 npm run webhook:register
 ```
+
+Webhook 可靠性规则：
+
+- `update_id` 是 delivery identity；已完成或仍处于新鲜 lease 的重复 delivery 不会重复执行副作用，超过 10 分钟的 `processing` 可被原子 reclaim。
+- Telegram 消息以 `(origin_channel_id, telegram_message_id)` 定位；`messages.id` 仅是稳定的归档/公共 identity，已有 ID 在编辑、reaction 和重放时保持不变。
+- 正文先写入 D1，媒体随后归档到稳定 R2 key。失败按 1、2、4、8 小时退避，第 5 次失败后停止自动重试；管理员显式重试会解除 exhausted 状态。
+- thumbnail 失败会保留已归档主媒体并进入可恢复失败；当前不支持的大型 document/audio 等文件会记录明确原因并停止自动重试，不会被误标为 archived。
 
 ## API
 

--- a/migrations/0005_webhook_media_reliability.sql
+++ b/migrations/0005_webhook_media_reliability.sql
@@ -1,0 +1,26 @@
+ALTER TABLE webhook_updates ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 1
+  CHECK (attempt_count >= 1);
+ALTER TABLE webhook_updates ADD COLUMN last_attempt_at TEXT;
+
+UPDATE webhook_updates
+SET last_attempt_at = COALESCE(processed_at, received_at)
+WHERE last_attempt_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS webhook_updates_claim_idx
+  ON webhook_updates(status, last_attempt_at);
+
+ALTER TABLE messages ADD COLUMN media_retry_count INTEGER NOT NULL DEFAULT 0
+  CHECK (media_retry_count >= 0);
+ALTER TABLE messages ADD COLUMN media_last_error TEXT;
+ALTER TABLE messages ADD COLUMN media_next_retry_at TEXT;
+ALTER TABLE messages ADD COLUMN media_retry_exhausted INTEGER NOT NULL DEFAULT 0
+  CHECK (media_retry_exhausted IN (0, 1));
+
+CREATE INDEX IF NOT EXISTS messages_media_retry_queue_idx
+  ON messages(
+    status,
+    media_retry_exhausted,
+    media_archive_status,
+    media_next_retry_at,
+    updated_at
+  );

--- a/src/cloudflare/api.ts
+++ b/src/cloudflare/api.ts
@@ -59,6 +59,7 @@ import {
   archiveMedia,
   archiveBotFile,
   extractTags,
+  MediaArchiveError,
   messageMedia,
   secretsMatch,
   shanghaiDate,
@@ -72,6 +73,18 @@ import {
 
 const PAGE_SIZE = 30;
 const MAX_PAGE_SIZE = 60;
+export const WEBHOOK_PROCESSING_LEASE_MS = 10 * 60 * 1000;
+export const MEDIA_MAX_RETRY_ATTEMPTS = 5;
+export const MEDIA_RETRY_DELAYS_MS = [
+  60 * 60 * 1000,
+  2 * 60 * 60 * 1000,
+  4 * 60 * 60 * 1000,
+  8 * 60 * 60 * 1000,
+] as const;
+
+export function mediaRetryDelayMs(failureCount: number): number | null {
+  return MEDIA_RETRY_DELAYS_MS[failureCount - 1] ?? null;
+}
 
 interface ChannelRow {
   id: string;
@@ -596,8 +609,16 @@ async function persistMessage(
   const time = shanghaiDate(message.date);
   const media = messageMedia(message);
   const archiveStatus = media.length ? "pending" : "none";
+  const replyTarget = message.reply_to_message
+    ? await env.DB.prepare(
+        `SELECT id FROM messages
+         WHERE COALESCE(origin_channel_id, channel_id) = ? AND telegram_message_id = ? LIMIT 1`,
+      )
+        .bind(channel.id, message.reply_to_message.message_id)
+        .first<{ id: string }>()
+    : null;
   const replyTo = message.reply_to_message
-    ? stableMessageId(channel.id, message.reply_to_message.message_id)
+    ? replyTarget?.id ?? stableMessageId(channel.id, message.reply_to_message.message_id)
     : null;
   const sourceUrl = `https://t.me/${channel.username}/${message.message_id}`;
   const tags = extractTags(text);
@@ -624,6 +645,10 @@ async function persistMessage(
          reply_to = excluded.reply_to,
          raw_payload = excluded.raw_payload,
          media_archive_status = excluded.media_archive_status,
+         media_retry_count = 0,
+         media_last_error = NULL,
+         media_next_retry_at = NULL,
+         media_retry_exhausted = 0,
          status = CASE WHEN messages.admin_override = 1 THEN messages.status ELSE 'published' END,
          updated_at = CURRENT_TIMESTAMP`,
     ).bind(
@@ -692,33 +717,54 @@ async function archiveAndUpdate(
   media: StoredMedia[],
 ): Promise<void> {
   if (!media.length) return;
+  let attempted = media;
   try {
-    const archived = await archiveMedia(
+    attempted = await archiveMedia(
       env,
       media,
       channel.id,
       channel.username,
       telegramMessageId,
     );
-    const status = archived.every((item) => item.archiveStatus === "archived")
+    const status = attempted.every((item) => item.archiveStatus === "archived")
       ? "archived"
-      : archived.some((item) => item.archiveStatus === "failed")
+      : attempted.some((item) => item.archiveStatus === "failed")
         ? "failed"
         : "external";
     await env.DB.prepare(
-      "UPDATE messages SET media = ?, media_archive_status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+      `UPDATE messages SET media = ?, media_archive_status = ?,
+       media_retry_count = 0, media_last_error = NULL, media_next_retry_at = NULL,
+       media_retry_exhausted = 0, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
     )
-      .bind(JSON.stringify(archived), status, id)
+      .bind(JSON.stringify(attempted), status, id)
       .run();
   } catch (error) {
-    const failed = media.map((item) => ({ ...item, archiveStatus: "failed" as const }));
+    const message = error instanceof Error ? error.message.slice(0, 500) : "Media archive failed";
+    const failed = error instanceof MediaArchiveError
+      ? error.media
+      : attempted.map((item) => ({ ...item, archiveStatus: "failed" as const }));
+    const current = await env.DB.prepare(
+      "SELECT media_retry_count FROM messages WHERE id = ?",
+    )
+      .bind(id)
+      .first<{ media_retry_count: number }>();
+    const failureCount = Number(current?.media_retry_count ?? 0) + 1;
+    const permanent = error instanceof MediaArchiveError && error.permanent;
+    const delay = mediaRetryDelayMs(failureCount);
+    const exhausted = permanent || failureCount >= MEDIA_MAX_RETRY_ATTEMPTS || delay === null;
+    const nextRetryAt = exhausted || delay === null
+      ? null
+      : new Date(Date.now() + delay).toISOString();
     await env.DB.batch([
       env.DB.prepare(
-        "UPDATE messages SET media = ?, media_archive_status = 'failed', updated_at = CURRENT_TIMESTAMP WHERE id = ?",
-      ).bind(JSON.stringify(failed), id),
+        `UPDATE messages SET media = ?, media_archive_status = 'failed',
+         media_retry_count = ?, media_last_error = ?, media_next_retry_at = ?,
+         media_retry_exhausted = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+      ).bind(JSON.stringify(failed), failureCount, message, nextRetryAt, exhausted ? 1 : 0, id),
       env.DB.prepare(
-        "INSERT INTO sync_logs(channel_id, source, status, message) VALUES (?, 'media', 'failed', ?)",
-      ).bind(channel.id, error instanceof Error ? error.message.slice(0, 500) : "Media archive failed"),
+        `INSERT INTO sync_logs(channel_id, source, status, message, details)
+         VALUES (?, 'media', 'failed', ?, ?)`,
+      ).bind(channel.id, message, JSON.stringify({ failureCount, exhausted, permanent })),
     ]);
   }
 }
@@ -726,9 +772,12 @@ async function archiveAndUpdate(
 async function processReaction(
   env: Env,
   reaction: TelegramReactionUpdate,
-): Promise<ChannelRow | null> {
+): Promise<{ channel: ChannelRow | null; status: "success" | "ignored" }> {
   const channel = await channelForChat(env, reaction.chat);
-  if (!channel) return null;
+  if (!channel) return { channel: null, status: "ignored" };
+  if (await isTombstoned(env, channel, reaction.message_id)) {
+    return { channel, status: "ignored" };
+  }
   const reactions = reaction.reactions.map((item) => ({
     emoji:
       item.type.emoji ??
@@ -743,19 +792,62 @@ async function processReaction(
     (total, item) => total + Math.max(0, Number(item.total_count) || 0),
     0,
   );
-  await env.DB.batch([
+  const results = await env.DB.batch([
     env.DB.prepare(
-      "UPDATE messages SET reactions = ?, engagement_score = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+      `UPDATE messages SET reactions = ?, engagement_score = ?, updated_at = CURRENT_TIMESTAMP
+       WHERE COALESCE(origin_channel_id, channel_id) = ? AND telegram_message_id = ?`,
     ).bind(
       JSON.stringify(reactions),
       engagementScore,
-      stableMessageId(channel.id, reaction.message_id),
+      channel.id,
+      reaction.message_id,
     ),
     env.DB.prepare(
       "UPDATE channels SET last_webhook_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
     ).bind(channel.id),
   ]);
-  return channel;
+  if ((results[0]?.meta.changes ?? 0) === 0) {
+    throw new Error("Reaction target message was not found");
+  }
+  return { channel, status: "success" };
+}
+
+async function claimWebhookUpdate(
+  env: Env,
+  updateId: string,
+): Promise<{ attemptCount: number } | null> {
+  const inserted = await env.DB.prepare(
+    `INSERT OR IGNORE INTO webhook_updates(
+       update_id, status, attempt_count, last_attempt_at
+     ) VALUES (?, 'processing', 1, CURRENT_TIMESTAMP)`,
+  )
+    .bind(updateId)
+    .run();
+  if ((inserted.meta.changes ?? 0) > 0) return { attemptCount: 1 };
+
+  const leaseMinutes = Math.floor(WEBHOOK_PROCESSING_LEASE_MS / 60_000);
+  const reclaimed = await env.DB.prepare(
+    `UPDATE webhook_updates
+     SET status = 'processing', error = NULL, processed_at = NULL,
+         attempt_count = attempt_count + 1, last_attempt_at = CURRENT_TIMESTAMP
+     WHERE update_id = ? AND (
+       status = 'failed' OR (
+         status = 'processing' AND (
+           last_attempt_at IS NULL OR
+           datetime(last_attempt_at) <= datetime(CURRENT_TIMESTAMP, ?)
+         )
+       )
+     )`,
+  )
+    .bind(updateId, `-${leaseMinutes} minutes`)
+    .run();
+  if ((reclaimed.meta.changes ?? 0) !== 1) return null;
+  const row = await env.DB.prepare(
+    "SELECT attempt_count FROM webhook_updates WHERE update_id = ?",
+  )
+    .bind(updateId)
+    .first<{ attempt_count: number }>();
+  return row ? { attemptCount: Number(row.attempt_count) } : null;
 }
 
 async function telegramWebhook(
@@ -778,25 +870,9 @@ async function telegramWebhook(
     return errorResponse(400, "Invalid JSON");
   }
   if (!Number.isInteger(update.update_id)) return errorResponse(400, "Missing update_id");
-
-  const inserted = await env.DB.prepare(
-    "INSERT OR IGNORE INTO webhook_updates(update_id, status) VALUES (?, 'processing')",
-  )
-    .bind(String(update.update_id))
-    .run();
-  if ((inserted.meta.changes ?? 0) === 0) {
-    const existing = await env.DB.prepare(
-      "SELECT status FROM webhook_updates WHERE update_id = ?",
-    )
-      .bind(String(update.update_id))
-      .first<{ status: string }>();
-    if (existing?.status !== "failed") return new Response(null, { status: 204 });
-    await env.DB.prepare(
-      "UPDATE webhook_updates SET status = 'processing', error = NULL WHERE update_id = ?",
-    )
-      .bind(String(update.update_id))
-      .run();
-  }
+  const updateId = String(update.update_id);
+  const claim = await claimWebhookUpdate(env, updateId);
+  if (!claim) return new Response(null, { status: 204 });
 
   try {
     const message = update.channel_post ?? update.edited_channel_post;
@@ -804,18 +880,20 @@ async function telegramWebhook(
       const channel = await channelForChat(env, message.chat);
       if (!channel) {
         await env.DB.prepare(
-          "UPDATE webhook_updates SET status = 'ignored', processed_at = CURRENT_TIMESTAMP WHERE update_id = ?",
+          `UPDATE webhook_updates SET status = 'ignored', processed_at = CURRENT_TIMESTAMP
+           WHERE update_id = ? AND status = 'processing' AND attempt_count = ?`,
         )
-          .bind(String(update.update_id))
+          .bind(updateId, claim.attemptCount)
           .run();
         return new Response(null, { status: 204 });
       }
       if (await isTombstoned(env, channel, message.message_id)) {
         await env.DB.prepare(
           `UPDATE webhook_updates SET channel_id = ?, telegram_message_id = ?,
-           status = 'ignored', processed_at = CURRENT_TIMESTAMP WHERE update_id = ?`,
+           status = 'ignored', processed_at = CURRENT_TIMESTAMP
+           WHERE update_id = ? AND status = 'processing' AND attempt_count = ?`,
         )
-          .bind(channel.id, message.message_id, String(update.update_id))
+          .bind(channel.id, message.message_id, updateId, claim.attemptCount)
           .run();
         return new Response(null, { status: 204 });
       }
@@ -831,37 +909,42 @@ async function telegramWebhook(
       else await archive;
       await env.DB.prepare(
         `UPDATE webhook_updates SET channel_id = ?, telegram_message_id = ?,
-         status = 'success', processed_at = CURRENT_TIMESTAMP WHERE update_id = ?`,
+         status = 'success', processed_at = CURRENT_TIMESTAMP
+         WHERE update_id = ? AND status = 'processing' AND attempt_count = ?`,
       )
-        .bind(channel.id, message.message_id, String(update.update_id))
+        .bind(channel.id, message.message_id, updateId, claim.attemptCount)
         .run();
     } else if (update.message_reaction_count) {
-      const channel = await processReaction(env, update.message_reaction_count);
+      const reaction = await processReaction(env, update.message_reaction_count);
       await env.DB.prepare(
         `UPDATE webhook_updates SET channel_id = ?, telegram_message_id = ?, status = ?,
-         processed_at = CURRENT_TIMESTAMP WHERE update_id = ?`,
+         processed_at = CURRENT_TIMESTAMP
+         WHERE update_id = ? AND status = 'processing' AND attempt_count = ?`,
       )
         .bind(
-          channel?.id ?? null,
+          reaction.channel?.id ?? null,
           update.message_reaction_count.message_id,
-          channel ? "success" : "ignored",
-          String(update.update_id),
+          reaction.status,
+          updateId,
+          claim.attemptCount,
         )
         .run();
     } else {
       await env.DB.prepare(
-        "UPDATE webhook_updates SET status = 'ignored', processed_at = CURRENT_TIMESTAMP WHERE update_id = ?",
+        `UPDATE webhook_updates SET status = 'ignored', processed_at = CURRENT_TIMESTAMP
+         WHERE update_id = ? AND status = 'processing' AND attempt_count = ?`,
       )
-        .bind(String(update.update_id))
+        .bind(updateId, claim.attemptCount)
         .run();
     }
     return new Response(null, { status: 204 });
   } catch (error) {
     const message = error instanceof Error ? error.message.slice(0, 500) : "Webhook failed";
     await env.DB.prepare(
-      "UPDATE webhook_updates SET status = 'failed', error = ?, processed_at = CURRENT_TIMESTAMP WHERE update_id = ?",
+      `UPDATE webhook_updates SET status = 'failed', error = ?, processed_at = CURRENT_TIMESTAMP
+       WHERE update_id = ? AND status = 'processing' AND attempt_count = ?`,
     )
-      .bind(message, String(update.update_id))
+      .bind(message, updateId, claim.attemptCount)
       .run();
     return errorResponse(500, "Webhook processing failed");
   }
@@ -1303,6 +1386,7 @@ async function configureTelegramWebhook(request: Request, env: Env): Promise<Res
 async function prepareMessageMediaRetry(
   env: Env,
   id: string,
+  manual = true,
 ): Promise<
   | { ok: false; status: number; error: string }
   | { ok: true; run: () => Promise<void> }
@@ -1318,12 +1402,18 @@ async function prepareMessageMediaRetry(
   if (!row) return { ok: false, status: 404, error: "Message not found" };
   const update = safeJsonParse<TelegramUpdate | null>(row.raw_payload, null);
   const message = update?.channel_post ?? update?.edited_channel_post;
-  const media = message ? messageMedia(message) : safeJsonParse<StoredMedia[]>(row.media, []);
+  const storedMedia = safeJsonParse<StoredMedia[]>(row.media, []);
+  const media = storedMedia.length ? storedMedia : message ? messageMedia(message) : [];
   if (!media.length) {
     return { ok: false, status: 409, error: "Message has no retryable Telegram media" };
   }
   await env.DB.prepare(
-    "UPDATE messages SET media_archive_status = 'pending', updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+    manual
+      ? `UPDATE messages SET media_archive_status = 'pending', media_retry_count = 0,
+         media_last_error = NULL, media_next_retry_at = NULL, media_retry_exhausted = 0,
+         updated_at = CURRENT_TIMESTAMP WHERE id = ?`
+      : `UPDATE messages SET media_archive_status = 'pending', media_next_retry_at = NULL,
+         updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
   )
     .bind(id)
     .run();
@@ -1333,8 +1423,8 @@ async function prepareMessageMediaRetry(
   };
 }
 
-async function retryMessageMedia(env: Env, id: string): Promise<Response> {
-  const prepared = await prepareMessageMediaRetry(env, id);
+async function retryMessageMedia(env: Env, id: string, manual = true): Promise<Response> {
+  const prepared = await prepareMessageMediaRetry(env, id, manual);
   if (!prepared.ok) return errorResponse(prepared.status, prepared.error);
   await prepared.run();
   const result = await env.DB.prepare(
@@ -1891,10 +1981,16 @@ export async function runHourlyMaintenance(env: Env): Promise<void> {
 
   const failed = await env.DB.prepare(
     `SELECT id FROM messages
-     WHERE media_archive_status IN ('pending', 'failed')
-     ORDER BY updated_at ASC LIMIT 1`,
+     WHERE status IN ('published', 'hidden')
+       AND media_archive_status IN ('pending', 'failed')
+       AND media_retry_exhausted = 0
+       AND (
+         media_next_retry_at IS NULL OR
+         datetime(media_next_retry_at) <= CURRENT_TIMESTAMP
+       )
+     ORDER BY COALESCE(media_next_retry_at, updated_at) ASC, updated_at ASC LIMIT 1`,
   ).first<{ id: string }>();
-  if (failed) await retryMessageMedia(env, failed.id);
+  if (failed) await retryMessageMedia(env, failed.id, false);
 
   const cleanup = await env.DB.prepare(
     `SELECT message_id FROM message_tombstones

--- a/src/cloudflare/telegram.ts
+++ b/src/cloudflare/telegram.ts
@@ -59,6 +59,17 @@ export interface TelegramUpdate {
   message_reaction_count?: TelegramReactionUpdate;
 }
 
+export class MediaArchiveError extends Error {
+  constructor(
+    message: string,
+    readonly media: StoredMedia[],
+    readonly permanent = false,
+  ) {
+    super(message);
+    this.name = "MediaArchiveError";
+  }
+}
+
 function escapeHtml(value: string): string {
   return value
     .replaceAll("&", "&amp;")
@@ -171,7 +182,7 @@ export function shanghaiDate(epochSeconds: number): {
 }
 
 export function stableMessageId(channelId: string, telegramMessageId: number): string {
-  return channelId === "geekshare" || channelId === "xgeekshare"
+  return channelId === "geekshare"
     ? `message${telegramMessageId}`
     : `${channelId}_${telegramMessageId}`;
 }
@@ -360,34 +371,30 @@ async function archiveThumbnail(
   telegramMessageId: number,
 ): Promise<string | undefined> {
   if (!item.thumbFileId || !item.thumbFileUniqueId) return item.thumbKey;
-  try {
-    const file = await telegramApi<{ file_path?: string; file_size?: number }>(
-      env,
-      "getFile",
-      { file_id: item.thumbFileId },
-    );
-    if (!file.file_path || (file.file_size ?? item.thumbSize ?? 0) > TELEGRAM_FILE_LIMIT) {
-      return item.thumbKey;
-    }
-    const thumbnail: StoredMedia = {
-      type: "photo",
-      archiveStatus: "pending",
-      mimeType: item.thumbMimeType ?? "image/jpeg",
-    };
-    const key = `channels/${channelId}/${telegramMessageId}/${item.thumbFileUniqueId}.${extensionFor(
-      file.file_path,
-      thumbnail,
-    )}`;
-    await streamToR2(
-      env,
-      key,
-      `https://api.telegram.org/file/bot${env.TELEGRAM_BOT_TOKEN}/${file.file_path}`,
-      thumbnail.mimeType,
-    );
-    return key;
-  } catch {
-    return item.thumbKey;
+  const file = await telegramApi<{ file_path?: string; file_size?: number }>(
+    env,
+    "getFile",
+    { file_id: item.thumbFileId },
+  );
+  if (!file.file_path || (file.file_size ?? item.thumbSize ?? 0) > TELEGRAM_FILE_LIMIT) {
+    throw new Error("Telegram thumbnail is unavailable through getFile");
   }
+  const thumbnail: StoredMedia = {
+    type: "photo",
+    archiveStatus: "pending",
+    mimeType: item.thumbMimeType ?? "image/jpeg",
+  };
+  const key = `channels/${channelId}/${telegramMessageId}/${item.thumbFileUniqueId}.${extensionFor(
+    file.file_path,
+    thumbnail,
+  )}`;
+  await streamToR2(
+    env,
+    key,
+    `https://api.telegram.org/file/bot${env.TELEGRAM_BOT_TOKEN}/${file.file_path}`,
+    thumbnail.mimeType,
+  );
+  return key;
 }
 
 export async function archiveMedia(
@@ -398,31 +405,38 @@ export async function archiveMedia(
   telegramMessageId: number,
 ): Promise<StoredMedia[]> {
   const archived: StoredMedia[] = [];
-  for (const item of media) {
-    if (item.archiveStatus === "external" || item.archiveStatus === "archived") {
-      archived.push(item);
-      continue;
-    }
-    if (!item.fileId || !item.fileUniqueId) {
-      throw new Error("Telegram media file identifier is missing");
-    }
-    const keyPrefix = `channels/${channelId}/${telegramMessageId}/${item.fileUniqueId}`;
-    let result: StoredMedia;
-    if ((item.size ?? 0) > TELEGRAM_FILE_LIMIT) {
-      result = await archiveFromEmbed(
-        env,
-        item,
-        channelUsername,
-        telegramMessageId,
-        keyPrefix,
-      );
-    } else {
-      const file = await telegramApi<{ file_path?: string; file_size?: number }>(
-        env,
-        "getFile",
-        { file_id: item.fileId },
-      );
-      if (!file.file_path || (file.file_size ?? 0) > TELEGRAM_FILE_LIMIT) {
+  for (let index = 0; index < media.length; index += 1) {
+    const item = media[index];
+    let result: StoredMedia | undefined;
+    try {
+      const thumbnailMissing = Boolean(item.thumbFileId && item.thumbFileUniqueId && !item.thumbKey);
+      if (
+        item.archiveStatus === "external" ||
+        (item.archiveStatus === "archived" && !thumbnailMissing)
+      ) {
+        archived.push(item);
+        continue;
+      }
+      if (item.r2Key && thumbnailMissing && await env.MEDIA.head(item.r2Key)) {
+        archived.push({
+          ...item,
+          thumbKey: await archiveThumbnail(env, item, channelId, telegramMessageId),
+          archiveStatus: "archived",
+        });
+        continue;
+      }
+      if (!item.fileId || !item.fileUniqueId) {
+        throw new Error("Telegram media file identifier is missing");
+      }
+      const keyPrefix = `channels/${channelId}/${telegramMessageId}/${item.fileUniqueId}`;
+      if ((item.size ?? 0) > TELEGRAM_FILE_LIMIT) {
+        if (item.type === "file") {
+          throw new MediaArchiveError(
+            "Oversized Telegram file media is unsupported by the current embed fallback",
+            [],
+            true,
+          );
+        }
         result = await archiveFromEmbed(
           env,
           item,
@@ -431,32 +445,60 @@ export async function archiveMedia(
           keyPrefix,
         );
       } else {
-        const extension = extensionFor(file.file_path, item);
-        const key = `${keyPrefix}.${extension}`;
-        const stored = await streamToR2(
+        const file = await telegramApi<{ file_path?: string; file_size?: number }>(
           env,
-          key,
-          `https://api.telegram.org/file/bot${env.TELEGRAM_BOT_TOKEN}/${file.file_path}`,
-          item.mimeType,
+          "getFile",
+          { file_id: item.fileId },
         );
-        result = {
-          ...item,
-          r2Key: key,
-          size: stored.size ?? file.file_size ?? item.size,
-          mimeType: stored.mimeType ?? item.mimeType,
-          archiveStatus: "archived",
-        };
+        if (!file.file_path || (file.file_size ?? 0) > TELEGRAM_FILE_LIMIT) {
+          if ((file.file_size ?? 0) > TELEGRAM_FILE_LIMIT && item.type === "file") {
+            throw new MediaArchiveError(
+              "Oversized Telegram file media is unsupported by the current embed fallback",
+              [],
+              true,
+            );
+          }
+          result = await archiveFromEmbed(
+            env,
+            item,
+            channelUsername,
+            telegramMessageId,
+            keyPrefix,
+          );
+        } else {
+          const extension = extensionFor(file.file_path, item);
+          const key = `${keyPrefix}.${extension}`;
+          const stored = await streamToR2(
+            env,
+            key,
+            `https://api.telegram.org/file/bot${env.TELEGRAM_BOT_TOKEN}/${file.file_path}`,
+            item.mimeType,
+          );
+          result = {
+            ...item,
+            r2Key: key,
+            size: stored.size ?? file.file_size ?? item.size,
+            mimeType: stored.mimeType ?? item.mimeType,
+            archiveStatus: "archived",
+          };
+        }
       }
+      archived.push({
+        ...result,
+        thumbKey: await archiveThumbnail(env, item, channelId, telegramMessageId),
+      });
+    } catch (error) {
+      const partial = result ?? item;
+      throw new MediaArchiveError(
+        error instanceof Error ? error.message : "Media archive failed",
+        [
+          ...archived,
+          { ...partial, archiveStatus: "failed" },
+          ...media.slice(index + 1),
+        ],
+        error instanceof MediaArchiveError && error.permanent,
+      );
     }
-    archived.push({
-      ...result,
-      thumbKey: await archiveThumbnail(
-        env,
-        item,
-        channelId,
-        telegramMessageId,
-      ),
-    });
   }
   return archived;
 }

--- a/src/lib/telegram/sync.ts
+++ b/src/lib/telegram/sync.ts
@@ -13,7 +13,7 @@ import {
 } from "@/lib/telegram/username";
 
 function messageIdFor(channelId: string, telegramMessageId: string): string {
-  return channelId === "geekshare" || channelId === "xgeekshare"
+  return channelId === "geekshare"
     ? `message${telegramMessageId}`
     : `${channelId}_${telegramMessageId}`;
 }

--- a/tests/cloudflare-test-helpers.ts
+++ b/tests/cloudflare-test-helpers.ts
@@ -1,0 +1,321 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { DatabaseSync, type SQLInputValue } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+import { handleApi } from "../src/cloudflare/api";
+import type {
+  D1Database,
+  D1PreparedStatement,
+  D1Result,
+  Env,
+  ExecutionContextLike,
+  R2Bucket,
+} from "../src/cloudflare/runtime";
+import type { TelegramUpdate } from "../src/cloudflare/telegram";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+export const ALL_MIGRATIONS = [
+  "0001_initial.sql",
+  "0002_admin_content_management.sql",
+  "0003_content_discovery.sql",
+  "0004_rebuild_messages_fts.sql",
+  "0005_webhook_media_reliability.sql",
+] as const;
+
+type FailureRule = {
+  match: (query: string) => boolean;
+  remaining: number;
+  message: string;
+};
+
+class LocalStatement implements D1PreparedStatement {
+  private values: SQLInputValue[] = [];
+
+  constructor(
+    private readonly owner: LocalD1,
+    readonly query: string,
+  ) {}
+
+  bind(...values: unknown[]): D1PreparedStatement {
+    this.values = values as SQLInputValue[];
+    return this;
+  }
+
+  async first<T = Record<string, unknown>>(columnName?: string): Promise<T | null> {
+    const row = this.owner.sqlite.prepare(this.query).get(...this.values) as Record<string, unknown> | undefined;
+    if (!row) return null;
+    return (columnName ? row[columnName] : { ...row }) as T;
+  }
+
+  async all<T = Record<string, unknown>>(): Promise<D1Result<T>> {
+    return {
+      results: (this.owner.sqlite.prepare(this.query).all(...this.values) as Record<string, unknown>[])
+        .map((row) => ({ ...row }) as T),
+      success: true,
+      meta: {},
+    };
+  }
+
+  async run<T = Record<string, unknown>>(): Promise<D1Result<T>> {
+    this.owner.executed.push(this.query);
+    this.owner.maybeFail(this.query);
+    const result = this.owner.sqlite.prepare(this.query).run(...this.values);
+    return {
+      success: true,
+      meta: {
+        changes: Number(result.changes),
+        last_row_id: Number(result.lastInsertRowid),
+      },
+    };
+  }
+}
+
+export class LocalD1 implements D1Database {
+  readonly sqlite = new DatabaseSync(":memory:");
+  readonly executed: string[] = [];
+  private readonly failures: FailureRule[] = [];
+
+  constructor(migrations: readonly string[] = ALL_MIGRATIONS) {
+    this.sqlite.exec("PRAGMA foreign_keys = ON");
+    for (const migration of migrations) this.applyMigration(migration);
+  }
+
+  applyMigration(file: string): void {
+    this.sqlite.exec(readFileSync(`${root}/migrations/${file}`, "utf8"));
+  }
+
+  prepare(query: string): D1PreparedStatement {
+    return new LocalStatement(this, query);
+  }
+
+  async batch<T = Record<string, unknown>>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+    this.sqlite.exec("BEGIN");
+    try {
+      const results: D1Result<T>[] = [];
+      for (const statement of statements) results.push(await statement.run<T>());
+      this.sqlite.exec("COMMIT");
+      return results;
+    } catch (error) {
+      this.sqlite.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  failOnce(match: (query: string) => boolean, message: string): void {
+    this.failures.push({ match, remaining: 1, message });
+  }
+
+  maybeFail(query: string): void {
+    const failure = this.failures.find((candidate) => candidate.remaining > 0 && candidate.match(query));
+    if (!failure) return;
+    failure.remaining -= 1;
+    throw new Error(failure.message);
+  }
+
+  countExecuted(fragment: string): number {
+    return this.executed.filter((query) => query.includes(fragment)).length;
+  }
+
+  row<T extends Record<string, unknown>>(query: string, ...values: unknown[]): T {
+    const row = this.sqlite.prepare(query).get(...values as SQLInputValue[]) as T | undefined;
+    assert.ok(row, `Expected row for ${query}`);
+    return { ...row };
+  }
+
+  scalar(query: string, ...values: unknown[]): number {
+    return Number(this.row<{ value: number }>(query, ...values).value);
+  }
+}
+
+export class LocalContext implements ExecutionContextLike {
+  readonly promises: Promise<unknown>[] = [];
+
+  waitUntil(promise: Promise<unknown>): void {
+    this.promises.push(promise);
+  }
+
+  async settle(): Promise<void> {
+    await Promise.allSettled(this.promises);
+  }
+}
+
+export class LocalMedia implements R2Bucket {
+  readonly keys = new Set<string>();
+  readonly heads: string[] = [];
+  readonly puts: string[] = [];
+  private readonly putFailures: Array<{ match: (key: string) => boolean; remaining: number }> = [];
+
+  failNextPut(match: (key: string) => boolean): void {
+    this.putFailures.push({ match, remaining: 1 });
+  }
+
+  async head(key: string) {
+    this.heads.push(key);
+    return this.keys.has(key) ? { key, size: 5 } : null;
+  }
+
+  async put(key: string) {
+    this.puts.push(key);
+    const failure = this.putFailures.find((candidate) => candidate.remaining > 0 && candidate.match(key));
+    if (failure) {
+      failure.remaining -= 1;
+      throw new Error(`Forced R2 PUT failure for ${key}`);
+    }
+    this.keys.add(key);
+    return { key, size: 5 };
+  }
+
+  async delete(keyOrKeys: string | string[]): Promise<void> {
+    for (const key of Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys]) this.keys.delete(key);
+  }
+}
+
+export function createTestEnv(
+  channels: Array<{ id: string; username: string; chatId: string }> = [
+    { id: "geekshare", username: "xgeekshare", chatId: "-1001" },
+  ],
+): { db: LocalD1; media: LocalMedia; env: Env } {
+  const db = new LocalD1();
+  for (const channel of channels) {
+    db.sqlite.prepare(
+      `INSERT INTO channels (
+         id, slug, title, username, telegram_chat_id, telegram_url, archive_url, enabled
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, 1)`,
+    ).run(
+      channel.id,
+      channel.id,
+      channel.id,
+      channel.username,
+      channel.chatId,
+      `https://t.me/${channel.username}`,
+      `/channel/${channel.id}`,
+    );
+  }
+  const media = new LocalMedia();
+  const env = {
+    DB: db,
+    MEDIA: media,
+    ASSETS: { fetch: async () => new Response("asset") },
+    SITE_URL: "https://archive.example.com",
+    MEDIA_BASE_URL: "https://media.example.com",
+    ENVIRONMENT: "test",
+    CF_ACCESS_ADMIN_EMAIL: "admin@example.com",
+    TELEGRAM_BOT_TOKEN: "token",
+    TELEGRAM_WEBHOOK_SECRET: "secret",
+  } as Env;
+  return { db, media, env };
+}
+
+export function messageUpdate(
+  updateId: number,
+  text: string,
+  options: {
+    messageId?: number;
+    chatId?: number;
+    username?: string;
+    edited?: boolean;
+    photo?: boolean;
+    replyToMessageId?: number;
+  } = {},
+): TelegramUpdate {
+  const message = {
+    message_id: options.messageId ?? 7,
+    date: 1_700_000_000,
+    ...(options.edited ? { edit_date: 1_700_000_100 } : {}),
+    chat: {
+      id: options.chatId ?? -1001,
+      title: "Channel",
+      username: options.username ?? "xgeekshare",
+      type: "channel",
+    },
+    text,
+    ...(options.replyToMessageId
+      ? { reply_to_message: { message_id: options.replyToMessageId } }
+      : {}),
+    ...(options.photo
+      ? { photo: [{ file_id: "photo-file", file_unique_id: "photo-unique", file_size: 100 }] }
+      : {}),
+  };
+  return options.edited
+    ? { update_id: updateId, edited_channel_post: message }
+    : { update_id: updateId, channel_post: message };
+}
+
+export function reactionUpdate(updateId: number, messageId = 7): TelegramUpdate {
+  return {
+    update_id: updateId,
+    message_reaction_count: {
+      chat: { id: -1001, username: "xgeekshare", type: "channel" },
+      message_id: messageId,
+      date: 1_700_000_200,
+      reactions: [{ type: { type: "emoji", emoji: "🔥" }, total_count: 3 }],
+    },
+  };
+}
+
+function webhookRequest(update: TelegramUpdate): Request {
+  return new Request("https://archive.example.com/api/telegram/webhook", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Telegram-Bot-Api-Secret-Token": "secret",
+    },
+    body: JSON.stringify(update),
+  });
+}
+
+export async function deliver(
+  env: Env,
+  update: TelegramUpdate,
+  useContext = false,
+): Promise<{ response: Response; context: LocalContext }> {
+  const context = new LocalContext();
+  const response = await handleApi(webhookRequest(update), env, useContext ? context : undefined);
+  return { response, context };
+}
+
+export function telegramFetch(options: {
+  failGetFile?: (fileId: string) => boolean;
+  oversized?: (fileId: string) => boolean;
+} = {}): {
+  handler: typeof fetch;
+  getFileIds: string[];
+} {
+  const getFileIds: string[] = [];
+  const handler = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const payload = typeof init?.body === "string"
+      ? JSON.parse(init.body) as { file_id?: string }
+      : {};
+    if (url.endsWith("/getWebhookInfo")) {
+      return Response.json({ ok: true, result: { url: "https://archive.example.com/api/telegram/webhook" } });
+    }
+    if (url.endsWith("/getFile")) {
+      const fileId = payload.file_id ?? "";
+      getFileIds.push(fileId);
+      if (options.failGetFile?.(fileId)) {
+        return Response.json({ ok: false, description: `Forced getFile failure for ${fileId}` }, { status: 500 });
+      }
+      const extension = fileId.includes("document") ? "pdf" : "jpg";
+      return Response.json({
+        ok: true,
+        result: {
+          file_path: `files/${fileId}.${extension}`,
+          file_size: options.oversized?.(fileId) ? 20 * 1024 * 1024 + 1 : 100,
+        },
+      });
+    }
+    if (url.includes("?embed=1")) {
+      return new Response(
+        '<a class="tgme_widget_message_photo_wrap" style="background-image:url(\'https://cdn.example/large.webp\')"></a>',
+      );
+    }
+    if (url.includes("/file/bot") || url.startsWith("https://cdn.example/")) {
+      return new Response("bytes", {
+        headers: { "Content-Type": url.endsWith(".pdf") ? "application/pdf" : "image/jpeg", "Content-Length": "5" },
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  }) as typeof fetch;
+  return { handler, getFileIds };
+}

--- a/tests/media-retry.test.ts
+++ b/tests/media-retry.test.ts
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  handleApi,
+  MEDIA_MAX_RETRY_ATTEMPTS,
+  mediaRetryDelayMs,
+  runHourlyMaintenance,
+} from "../src/cloudflare/api";
+import type { TelegramUpdate } from "../src/cloudflare/telegram";
+import {
+  createTestEnv,
+  deliver,
+  messageUpdate,
+  telegramFetch,
+} from "./cloudflare-test-helpers";
+
+test("media failure preserves text, records retry metadata, and duplicate delivery has no second side effect", async (context) => {
+  const mocked = telegramFetch({ failGetFile: (fileId) => fileId === "photo-file" });
+  context.mock.method(globalThis, "fetch", mocked.handler);
+  const { db, env } = createTestEnv();
+  const update = messageUpdate(100, "body survives #media", { photo: true });
+  const first = await deliver(env, update, true);
+  await first.context.settle();
+  const duplicate = await deliver(env, update, true);
+  await duplicate.context.settle();
+
+  const row = db.row<{
+    plain_text: string;
+    media_archive_status: string;
+    media_retry_count: number;
+    media_last_error: string;
+    media_next_retry_at: string;
+    media_retry_exhausted: number;
+  }>(
+    `SELECT plain_text, media_archive_status, media_retry_count, media_last_error,
+            media_next_retry_at, media_retry_exhausted
+     FROM messages WHERE id = 'message7'`,
+  );
+  assert.equal(row.plain_text, "body survives #media");
+  assert.equal(row.media_archive_status, "failed");
+  assert.equal(row.media_retry_count, 1);
+  assert.match(row.media_last_error, /Forced getFile failure/);
+  assert.ok(Date.parse(row.media_next_retry_at) > Date.now());
+  assert.equal(row.media_retry_exhausted, 0);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM sync_logs WHERE source = 'media'"), 1);
+  assert.deepEqual([first.response.status, duplicate.response.status], [204, 204]);
+});
+
+test("R2 success followed by D1 failure recovers through HEAD without a duplicate PUT", async (context) => {
+  const mocked = telegramFetch();
+  context.mock.method(globalThis, "fetch", mocked.handler);
+  const { db, env, media } = createTestEnv();
+  db.failOnce(
+    (query) => query.includes("UPDATE messages SET media = ?, media_archive_status = ?"),
+    "forced post-R2 D1 failure",
+  );
+  const delivered = await deliver(env, messageUpdate(101, "r2 before d1", { photo: true }), true);
+  await delivered.context.settle();
+  assert.deepEqual(
+    db.row("SELECT media_archive_status, media_retry_count FROM messages WHERE id = 'message7'"),
+    { media_archive_status: "failed", media_retry_count: 1 },
+  );
+  assert.equal(media.puts.filter((key) => key.includes("photo-unique")).length, 1);
+
+  db.sqlite.prepare(
+    "UPDATE messages SET media_next_retry_at = datetime('now', '-1 minute') WHERE id = 'message7'",
+  ).run();
+  await runHourlyMaintenance(env);
+  assert.deepEqual(
+    db.row(
+      `SELECT media_archive_status, media_retry_count, media_last_error,
+              media_next_retry_at, media_retry_exhausted
+       FROM messages WHERE id = 'message7'`,
+    ),
+    {
+      media_archive_status: "archived",
+      media_retry_count: 0,
+      media_last_error: null,
+      media_next_retry_at: null,
+      media_retry_exhausted: 0,
+    },
+  );
+  assert.equal(media.puts.filter((key) => key.includes("photo-unique")).length, 1);
+  assert.ok(media.heads.filter((key) => key.includes("photo-unique")).length >= 2);
+});
+
+test("thumbnail failure remains retryable and recovery only HEAD-checks the archived main object", async (context) => {
+  const mocked = telegramFetch();
+  context.mock.method(globalThis, "fetch", mocked.handler);
+  const { db, env, media } = createTestEnv();
+  media.failNextPut((key) => key.includes("thumb-unique"));
+  const update: TelegramUpdate = {
+    update_id: 102,
+    channel_post: {
+      message_id: 7,
+      date: 1_700_000_000,
+      chat: { id: -1001, username: "xgeekshare", type: "channel" },
+      document: {
+        file_id: "document-file",
+        file_unique_id: "document-unique",
+        file_size: 100,
+        file_name: "document.pdf",
+        mime_type: "application/pdf",
+        thumbnail: {
+          file_id: "thumb-file",
+          file_unique_id: "thumb-unique",
+          file_size: 20,
+          mime_type: "image/jpeg",
+        },
+      },
+    },
+  };
+  const delivered = await deliver(env, update, true);
+  await delivered.context.settle();
+  const failed = db.row<{ media_archive_status: string; media: string; media_retry_count: number }>(
+    "SELECT media_archive_status, media, media_retry_count FROM messages WHERE id = 'message7'",
+  );
+  const failedMedia = JSON.parse(failed.media) as Array<{ r2Key?: string; thumbKey?: string; archiveStatus: string }>;
+  assert.equal(failed.media_archive_status, "failed");
+  assert.equal(failed.media_retry_count, 1);
+  assert.equal(failedMedia[0].r2Key, "channels/geekshare/7/document-unique.pdf");
+  assert.equal(failedMedia[0].thumbKey, undefined);
+  assert.equal(failedMedia[0].archiveStatus, "failed");
+  assert.equal(media.puts.filter((key) => key.includes("document-unique")).length, 1);
+
+  db.sqlite.prepare(
+    "UPDATE messages SET media_next_retry_at = datetime('now', '-1 minute') WHERE id = 'message7'",
+  ).run();
+  await runHourlyMaintenance(env);
+  const recovered = db.row<{ media_archive_status: string; media: string; media_retry_count: number }>(
+    "SELECT media_archive_status, media, media_retry_count FROM messages WHERE id = 'message7'",
+  );
+  const recoveredMedia = JSON.parse(recovered.media) as Array<{ r2Key?: string; thumbKey?: string }>;
+  assert.equal(recovered.media_archive_status, "archived");
+  assert.equal(recovered.media_retry_count, 0);
+  assert.equal(recoveredMedia[0].r2Key, "channels/geekshare/7/document-unique.pdf");
+  assert.equal(recoveredMedia[0].thumbKey, "channels/geekshare/7/thumb-unique.jpg");
+  assert.equal(media.puts.filter((key) => key.includes("document-unique")).length, 1);
+  assert.ok(media.heads.filter((key) => key.includes("document-unique")).length >= 2);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM sync_logs WHERE source = 'media'"), 1);
+});
+
+test("automatic media retry uses bounded exponential backoff and stops after exhaustion", async (context) => {
+  let failing = true;
+  const mocked = telegramFetch({ failGetFile: (fileId) => failing && fileId === "photo-file" });
+  context.mock.method(globalThis, "fetch", mocked.handler);
+  const { db, env } = createTestEnv();
+  const delivered = await deliver(env, messageUpdate(103, "bounded retry", { photo: true }), true);
+  await delivered.context.settle();
+  assert.equal(MEDIA_MAX_RETRY_ATTEMPTS, 5);
+  assert.deepEqual(
+    [1, 2, 3, 4, 5].map(mediaRetryDelayMs),
+    [3_600_000, 7_200_000, 14_400_000, 28_800_000, null],
+  );
+
+  for (let expected = 2; expected <= MEDIA_MAX_RETRY_ATTEMPTS; expected += 1) {
+    db.sqlite.prepare(
+      "UPDATE messages SET media_next_retry_at = datetime('now', '-1 minute') WHERE id = 'message7'",
+    ).run();
+    await runHourlyMaintenance(env);
+    assert.equal(
+      db.row<{ media_retry_count: number }>("SELECT media_retry_count FROM messages WHERE id = 'message7'").media_retry_count,
+      expected,
+    );
+  }
+  assert.deepEqual(
+    db.row(
+      `SELECT media_archive_status, media_retry_count, media_next_retry_at,
+              media_retry_exhausted
+       FROM messages WHERE id = 'message7'`,
+    ),
+    {
+      media_archive_status: "failed",
+      media_retry_count: 5,
+      media_next_retry_at: null,
+      media_retry_exhausted: 1,
+    },
+  );
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM sync_logs WHERE source = 'media'"), 5);
+  await runHourlyMaintenance(env);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM sync_logs WHERE source = 'media'"), 5);
+
+  failing = false;
+  const manual = await handleApi(
+    new Request("https://archive.example.com/api/admin/messages/message7/retry-media", {
+      method: "POST",
+      headers: { Origin: "https://archive.example.com" },
+    }),
+    env,
+  );
+  assert.equal(manual.status, 200);
+  assert.deepEqual(
+    db.row("SELECT media_archive_status, media_retry_count, media_retry_exhausted FROM messages WHERE id = 'message7'"),
+    { media_archive_status: "archived", media_retry_count: 0, media_retry_exhausted: 0 },
+  );
+});
+
+test("scheduled retry skips deleting rows and processes the next eligible message", async (context) => {
+  let failing = true;
+  const mocked = telegramFetch({ failGetFile: () => failing });
+  context.mock.method(globalThis, "fetch", mocked.handler);
+  const { db, env } = createTestEnv();
+  const first = await deliver(env, messageUpdate(104, "deleting", { photo: true }), true);
+  const second = await deliver(env, messageUpdate(105, "eligible", { messageId: 8, photo: true }), true);
+  await Promise.all([first.context.settle(), second.context.settle()]);
+  db.sqlite.prepare(
+    `UPDATE messages SET status = 'deleting', media_next_retry_at = datetime('now', '-2 hours'),
+       updated_at = datetime('now', '-2 hours') WHERE id = 'message7'`,
+  ).run();
+  db.sqlite.prepare(
+    `UPDATE messages SET media_next_retry_at = datetime('now', '-1 hour'),
+       updated_at = datetime('now', '-1 hour') WHERE id = 'message8'`,
+  ).run();
+
+  failing = false;
+  await runHourlyMaintenance(env);
+  assert.equal(
+    db.row<{ media_archive_status: string }>("SELECT media_archive_status FROM messages WHERE id = 'message7'").media_archive_status,
+    "failed",
+  );
+  assert.equal(
+    db.row<{ media_archive_status: string }>("SELECT media_archive_status FROM messages WHERE id = 'message8'").media_archive_status,
+    "archived",
+  );
+});
+
+test("oversized unsupported file media records a permanent explicit failure and is not auto-retried", async (context) => {
+  const mocked = telegramFetch();
+  context.mock.method(globalThis, "fetch", mocked.handler);
+  const { db, env } = createTestEnv();
+  const update: TelegramUpdate = {
+    update_id: 106,
+    channel_post: {
+      message_id: 7,
+      date: 1_700_000_000,
+      chat: { id: -1001, username: "xgeekshare", type: "channel" },
+      document: {
+        file_id: "large-document",
+        file_unique_id: "large-document-unique",
+        file_size: 20 * 1024 * 1024 + 1,
+        file_name: "large.pdf",
+        mime_type: "application/pdf",
+      },
+    },
+  };
+  const delivered = await deliver(env, update, true);
+  await delivered.context.settle();
+  const row = db.row<{
+    media_archive_status: string;
+    media_retry_count: number;
+    media_last_error: string;
+    media_next_retry_at: string | null;
+    media_retry_exhausted: number;
+  }>(
+    `SELECT media_archive_status, media_retry_count, media_last_error,
+            media_next_retry_at, media_retry_exhausted
+     FROM messages WHERE id = 'message7'`,
+  );
+  assert.equal(row.media_archive_status, "failed");
+  assert.equal(row.media_retry_count, 1);
+  assert.match(row.media_last_error, /Oversized Telegram file media is unsupported/);
+  assert.equal(row.media_next_retry_at, null);
+  assert.equal(row.media_retry_exhausted, 1);
+  assert.equal(mocked.getFileIds.length, 0);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM sync_logs WHERE source = 'media'"), 1);
+  await runHourlyMaintenance(env);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM sync_logs WHERE source = 'media'"), 1);
+});

--- a/tests/reliability-migration.test.ts
+++ b/tests/reliability-migration.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { ALL_MIGRATIONS, LocalD1 } from "./cloudflare-test-helpers";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const wrangler = path.join(root, "node_modules", "wrangler", "bin", "wrangler.js");
+
+function columns(db: LocalD1, table: string): string[] {
+  return (db.sqlite.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map(({ name }) => name);
+}
+
+test("fresh schema applies webhook lease and media retry migration", () => {
+  const db = new LocalD1();
+  assert.deepEqual(
+    columns(db, "webhook_updates").filter((name) => ["attempt_count", "last_attempt_at"].includes(name)),
+    ["attempt_count", "last_attempt_at"],
+  );
+  assert.deepEqual(
+    columns(db, "messages").filter((name) => [
+      "media_retry_count",
+      "media_last_error",
+      "media_next_retry_at",
+      "media_retry_exhausted",
+    ].includes(name)),
+    ["media_retry_count", "media_last_error", "media_next_retry_at", "media_retry_exhausted"],
+  );
+  assert.ok(
+    (db.sqlite.prepare("PRAGMA index_list(webhook_updates)").all() as Array<{ name: string }>)
+      .some(({ name }) => name === "webhook_updates_claim_idx"),
+  );
+  assert.ok(
+    (db.sqlite.prepare("PRAGMA index_list(messages)").all() as Array<{ name: string }>)
+      .some(({ name }) => name === "messages_media_retry_queue_idx"),
+  );
+});
+
+test("0005 upgrades an existing 0001-0004 database without losing messages, FTS, or webhook history", () => {
+  const db = new LocalD1(ALL_MIGRATIONS.slice(0, 4));
+  db.sqlite.exec(`
+    INSERT INTO channels (
+      id, slug, title, username, telegram_url, archive_url
+    ) VALUES (
+      'geekshare', 'geekshare', 'GeekShare', 'xgeekshare',
+      'https://t.me/xgeekshare', '/channel/geekshare'
+    );
+    INSERT INTO messages (
+      id, channel_id, origin_channel_id, telegram_message_id, source_url, date,
+      published_at, published_year, published_month, plain_text, media_archive_status
+    ) VALUES (
+      'message7', 'geekshare', 'geekshare', 7, 'https://t.me/xgeekshare/7',
+      '2023-11-15', 1700000000, '2023', '2023-11', 'migration keeps this text', 'failed'
+    );
+    INSERT INTO webhook_updates(
+      update_id, channel_id, telegram_message_id, status, error, received_at, processed_at
+    ) VALUES (
+      '100', 'geekshare', 7, 'failed', 'old error', '2026-08-27 10:00:00', '2026-08-27 10:01:00'
+    );
+  `);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages"), 1);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages_fts WHERE id = 'message7'"), 1);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM webhook_updates"), 1);
+
+  db.applyMigration("0005_webhook_media_reliability.sql");
+  assert.deepEqual(
+    db.row(
+      `SELECT id, plain_text, media_archive_status, media_retry_count, media_last_error,
+              media_next_retry_at, media_retry_exhausted
+       FROM messages WHERE id = 'message7'`,
+    ),
+    {
+      id: "message7",
+      plain_text: "migration keeps this text",
+      media_archive_status: "failed",
+      media_retry_count: 0,
+      media_last_error: null,
+      media_next_retry_at: null,
+      media_retry_exhausted: 0,
+    },
+  );
+  assert.deepEqual(
+    db.row(
+      `SELECT update_id, status, error, received_at, processed_at,
+              attempt_count, last_attempt_at
+       FROM webhook_updates WHERE update_id = '100'`,
+    ),
+    {
+      update_id: "100",
+      status: "failed",
+      error: "old error",
+      received_at: "2026-08-27 10:00:00",
+      processed_at: "2026-08-27 10:01:00",
+      attempt_count: 1,
+      last_attempt_at: "2026-08-27 10:01:00",
+    },
+  );
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages_fts WHERE id = 'message7'"), 1);
+  assert.equal(
+    db.scalar("SELECT COUNT(*) AS value FROM messages_fts WHERE messages_fts MATCH '\"migration keeps this text\"'"),
+    1,
+  );
+});
+
+test("Wrangler recognizes 0005 for both fresh apply and existing local D1 upgrade", () => {
+  const temporary = mkdtempSync(path.join(tmpdir(), "geekshare-reliability-migration-"));
+  const migrations = path.join(temporary, "migrations");
+  const xdgConfig = path.join(temporary, "xdg");
+  const upgradePersistence = path.join(temporary, "upgrade-d1");
+  const freshPersistence = path.join(temporary, "fresh-d1");
+  const config = path.join(temporary, "wrangler.json");
+  mkdirSync(migrations, { recursive: true });
+  mkdirSync(xdgConfig, { recursive: true });
+  for (const migration of ALL_MIGRATIONS.slice(0, 4)) {
+    copyFileSync(path.join(root, "migrations", migration), path.join(migrations, migration));
+  }
+  writeFileSync(config, JSON.stringify({
+    name: "geekshare-migration-test",
+    main: path.join(root, "src", "worker.ts").replaceAll("\\", "/"),
+    compatibility_date: "2026-08-16",
+    d1_databases: [{
+      binding: "DB",
+      database_name: "geekshare-archive",
+      database_id: "00000000-0000-0000-0000-000000000000",
+      migrations_dir: migrations.replaceAll("\\", "/"),
+    }],
+  }));
+
+  const run = (args: string[], persistence: string): string => {
+    const result = spawnSync(
+      process.execPath,
+      [wrangler, ...args, "--local", "--persist-to", persistence, "--config", config],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: { ...process.env, CI: "1", XDG_CONFIG_HOME: xdgConfig },
+        maxBuffer: 10 * 1024 * 1024,
+      },
+    );
+    if (result.status !== 0) throw new Error([result.stderr, result.stdout].filter(Boolean).join("\n"));
+    return result.stdout;
+  };
+
+  try {
+    run(["d1", "migrations", "apply", "geekshare-archive"], upgradePersistence);
+    run([
+      "d1", "execute", "geekshare-archive", "--command",
+      `INSERT INTO channels(id, slug, title, username, telegram_url, archive_url)
+       VALUES ('geekshare', 'geekshare', 'GeekShare', 'xgeekshare', 'https://t.me/xgeekshare', '/channel/geekshare');
+       INSERT INTO messages(
+         id, channel_id, origin_channel_id, telegram_message_id, source_url, date,
+         published_at, published_year, published_month, plain_text, media_archive_status
+       ) VALUES (
+         'message7', 'geekshare', 'geekshare', 7, 'https://t.me/xgeekshare/7',
+         '2023-11-15', 1700000000, '2023', '2023-11', 'wrangler upgrade text', 'failed'
+       );
+       INSERT INTO webhook_updates(update_id, status) VALUES ('100', 'processing');`,
+    ], upgradePersistence);
+    copyFileSync(
+      path.join(root, "migrations", "0005_webhook_media_reliability.sql"),
+      path.join(migrations, "0005_webhook_media_reliability.sql"),
+    );
+    const upgraded = run(["d1", "migrations", "apply", "geekshare-archive"], upgradePersistence);
+    assert.match(upgraded, /0005_webhook_media_reliability\.sql/);
+    const upgradeQuery = JSON.parse(run([
+      "d1", "execute", "geekshare-archive", "--command",
+      `SELECT COUNT(*) AS messages FROM messages;
+       SELECT COUNT(*) AS fts FROM messages_fts;
+       SELECT COUNT(*) AS updates FROM webhook_updates;
+       SELECT media_retry_count, media_retry_exhausted FROM messages WHERE id = 'message7';
+       SELECT attempt_count, last_attempt_at IS NOT NULL AS has_attempt_at
+       FROM webhook_updates WHERE update_id = '100';`,
+      "--json",
+    ], upgradePersistence)) as Array<{ results: Array<Record<string, number>> }>;
+    assert.deepEqual(upgradeQuery.map(({ results }) => results[0]), [
+      { messages: 1 },
+      { fts: 1 },
+      { updates: 1 },
+      { media_retry_count: 0, media_retry_exhausted: 0 },
+      { attempt_count: 1, has_attempt_at: 1 },
+    ]);
+
+    const fresh = run(["d1", "migrations", "apply", "geekshare-archive"], freshPersistence);
+    assert.match(fresh, /0001_initial\.sql/);
+    assert.match(fresh, /0005_webhook_media_reliability\.sql/);
+    const freshQuery = JSON.parse(run([
+      "d1", "execute", "geekshare-archive", "--command",
+      `SELECT COUNT(*) AS webhook_columns FROM pragma_table_info('webhook_updates')
+       WHERE name IN ('attempt_count', 'last_attempt_at');
+       SELECT COUNT(*) AS media_columns FROM pragma_table_info('messages')
+       WHERE name IN ('media_retry_count', 'media_last_error', 'media_next_retry_at', 'media_retry_exhausted');`,
+      "--json",
+    ], freshPersistence)) as Array<{ results: Array<Record<string, number>> }>;
+    assert.deepEqual(freshQuery.map(({ results }) => results[0]), [
+      { webhook_columns: 2 },
+      { media_columns: 4 },
+    ]);
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+});

--- a/tests/telegram.test.ts
+++ b/tests/telegram.test.ts
@@ -37,6 +37,7 @@ test("date and stable IDs preserve existing links", () => {
     month: "1970-01",
   });
   assert.equal(stableMessageId("geekshare", 42), "message42");
+  assert.equal(stableMessageId("xgeekshare", 42), "xgeekshare_42");
   assert.equal(stableMessageId("tl_gc", 42), "tl_gc_42");
 });
 

--- a/tests/webhook-reliability.test.ts
+++ b/tests/webhook-reliability.test.ts
@@ -1,0 +1,285 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { handleApi, WEBHOOK_PROCESSING_LEASE_MS } from "../src/cloudflare/api";
+import {
+  createTestEnv,
+  deliver,
+  messageUpdate,
+  reactionUpdate,
+} from "./cloudflare-test-helpers";
+
+test("webhook claims first delivery, skips terminal and fresh duplicates, and retries failed updates", async () => {
+  const { db, env } = createTestEnv();
+  const update = messageUpdate(1, "first #one");
+  assert.equal((await deliver(env, update)).response.status, 204);
+  assert.equal((await deliver(env, update)).response.status, 204);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages"), 1);
+  assert.equal(db.countExecuted("INSERT INTO messages"), 1);
+  assert.deepEqual(
+    db.row("SELECT status, attempt_count FROM webhook_updates WHERE update_id = '1'"),
+    { status: "success", attempt_count: 1 },
+  );
+
+  db.sqlite.prepare(
+    `INSERT INTO webhook_updates(update_id, status, attempt_count, last_attempt_at)
+     VALUES ('2', 'processing', 1, CURRENT_TIMESTAMP)`,
+  ).run();
+  assert.equal((await deliver(env, messageUpdate(2, "fresh duplicate", { messageId: 8 }))).response.status, 204);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages WHERE telegram_message_id = 8"), 0);
+  assert.deepEqual(
+    db.row("SELECT status, attempt_count FROM webhook_updates WHERE update_id = '2'"),
+    { status: "processing", attempt_count: 1 },
+  );
+
+  db.failOnce((query) => query.includes("INSERT INTO messages"), "forced insert failure");
+  assert.equal((await deliver(env, messageUpdate(3, "retry", { messageId: 9 }))).response.status, 500);
+  const failed = db.row<{ status: string; processed_at: string | null }>(
+    "SELECT status, processed_at FROM webhook_updates WHERE update_id = '3'",
+  );
+  assert.equal(failed.status, "failed");
+  assert.ok(failed.processed_at);
+  assert.equal((await deliver(env, messageUpdate(3, "retry", { messageId: 9 }))).response.status, 204);
+  assert.deepEqual(
+    db.row("SELECT status, error, attempt_count FROM webhook_updates WHERE update_id = '3'"),
+    { status: "success", error: null, attempt_count: 2 },
+  );
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages WHERE telegram_message_id = 9"), 1);
+});
+
+test("stale processing is reclaimed with a conditional claim and only one concurrent replay wins", async () => {
+  assert.equal(WEBHOOK_PROCESSING_LEASE_MS, 10 * 60 * 1000);
+  const { db, env } = createTestEnv();
+  db.sqlite.prepare(
+    `INSERT INTO webhook_updates(update_id, status, attempt_count, last_attempt_at)
+     VALUES ('10', 'processing', 1, datetime('now', '-11 minutes'))`,
+  ).run();
+  const update = messageUpdate(10, "stale replay");
+  const responses = await Promise.all([deliver(env, update), deliver(env, update)]);
+  assert.deepEqual(responses.map(({ response }) => response.status), [204, 204]);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages"), 1);
+  assert.equal(db.countExecuted("INSERT INTO messages"), 1);
+  assert.deepEqual(
+    db.row("SELECT status, attempt_count FROM webhook_updates WHERE update_id = '10'"),
+    { status: "success", attempt_count: 2 },
+  );
+});
+
+test("failed retry clears terminal metadata and starts a new counted attempt", async () => {
+  const { db, env } = createTestEnv();
+  db.sqlite.prepare(
+    `INSERT INTO webhook_updates(
+       update_id, status, error, received_at, processed_at, attempt_count, last_attempt_at
+     ) VALUES (
+       '11', 'failed', 'old failure', '2026-08-27 10:00:00', '2026-08-27 10:01:00',
+       1, '2026-08-27 10:00:00'
+     )`,
+  ).run();
+  db.failOnce((query) => query.includes("INSERT INTO messages"), "second attempt interrupted");
+  db.failOnce((query) => query.includes("SET status = 'failed'"), "terminal state interrupted");
+  await assert.rejects(deliver(env, messageUpdate(11, "retry metadata")), /terminal state interrupted/);
+  const row = db.row<{
+    status: string;
+    error: string | null;
+    received_at: string;
+    processed_at: string | null;
+    attempt_count: number;
+    last_attempt_at: string;
+  }>(
+    `SELECT status, error, received_at, processed_at, attempt_count, last_attempt_at
+     FROM webhook_updates WHERE update_id = '11'`,
+  );
+  assert.equal(row.status, "processing");
+  assert.equal(row.error, null);
+  assert.equal(row.received_at, "2026-08-27 10:00:00");
+  assert.equal(row.processed_at, null);
+  assert.equal(row.attempt_count, 2);
+  assert.notEqual(row.last_attempt_at, "2026-08-27 10:00:00");
+});
+
+test("crash before message insert recovers after the processing lease becomes stale", async () => {
+  const { db, env } = createTestEnv();
+  db.failOnce((query) => query.includes("INSERT INTO messages"), "crash before message insert");
+  db.failOnce((query) => query.includes("SET status = 'failed'"), "terminal state unavailable");
+  const update = messageUpdate(20, "crash A");
+  await assert.rejects(deliver(env, update), /terminal state unavailable/);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages"), 0);
+  assert.deepEqual(
+    db.row("SELECT status, processed_at, attempt_count FROM webhook_updates WHERE update_id = '20'"),
+    { status: "processing", processed_at: null, attempt_count: 1 },
+  );
+
+  db.sqlite.prepare(
+    "UPDATE webhook_updates SET last_attempt_at = datetime('now', '-11 minutes') WHERE update_id = '20'",
+  ).run();
+  assert.equal((await deliver(env, update)).response.status, 204);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages"), 1);
+  assert.deepEqual(
+    db.row("SELECT status, attempt_count FROM webhook_updates WHERE update_id = '20'"),
+    { status: "success", attempt_count: 2 },
+  );
+});
+
+test("crash after message commit recovers by upserting the same archive row and FTS row", async () => {
+  const { db, env } = createTestEnv();
+  db.failOnce(
+    (query) => query.includes("UPDATE webhook_updates SET channel_id") && query.includes("status = 'success'"),
+    "success state unavailable",
+  );
+  db.failOnce((query) => query.includes("SET status = 'failed'"), "failed state unavailable");
+  const update = messageUpdate(21, "crash B current text");
+  await assert.rejects(deliver(env, update), /failed state unavailable/);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages"), 1);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages_fts WHERE id = 'message7'"), 1);
+  assert.equal(db.row<{ status: string }>("SELECT status FROM webhook_updates WHERE update_id = '21'").status, "processing");
+
+  db.sqlite.prepare(
+    "UPDATE webhook_updates SET last_attempt_at = datetime('now', '-11 minutes') WHERE update_id = '21'",
+  ).run();
+  assert.equal((await deliver(env, update)).response.status, 204);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages"), 1);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages_fts WHERE id = 'message7'"), 1);
+  assert.equal(
+    db.scalar("SELECT COUNT(*) AS value FROM messages_fts WHERE messages_fts MATCH '\"crash B current text\"'"),
+    1,
+  );
+  assert.deepEqual(
+    db.row("SELECT status, attempt_count FROM webhook_updates WHERE update_id = '21'"),
+    { status: "success", attempt_count: 2 },
+  );
+});
+
+test("composite Telegram identity preserves existing IDs and allows equal message numbers across channels", async () => {
+  const { db, env } = createTestEnv([
+    { id: "geekshare", username: "firstchannel", chatId: "-1001" },
+    { id: "xgeekshare", username: "secondchannel", chatId: "-1002" },
+  ]);
+  assert.equal((await deliver(env, messageUpdate(30, "first", { messageId: 123, username: "firstchannel" }))).response.status, 204);
+  assert.equal((await deliver(env, messageUpdate(31, "second", { messageId: 123, chatId: -1002, username: "secondchannel" }))).response.status, 204);
+  assert.deepEqual(
+    db.sqlite.prepare("SELECT id, origin_channel_id FROM messages ORDER BY origin_channel_id").all()
+      .map((row) => ({ ...row })),
+    [
+      { id: "message123", origin_channel_id: "geekshare" },
+      { id: "xgeekshare_123", origin_channel_id: "xgeekshare" },
+    ],
+  );
+
+  db.sqlite.prepare(
+    `INSERT INTO messages (
+       id, channel_id, origin_channel_id, telegram_message_id, source_url, date,
+       published_at, published_year, published_month, plain_text
+     ) VALUES (
+       'preserved-public-id', 'xgeekshare', 'xgeekshare', 124,
+       'https://t.me/secondchannel/124', '2023-11-15', 1700000000,
+       '2023', '2023-11', 'old text'
+     )`,
+  ).run();
+  assert.equal((await deliver(env, messageUpdate(32, "updated existing", { messageId: 124, chatId: -1002, username: "secondchannel" }))).response.status, 204);
+  assert.deepEqual(
+    db.row("SELECT id, plain_text FROM messages WHERE origin_channel_id = 'xgeekshare' AND telegram_message_id = 124"),
+    { id: "preserved-public-id", plain_text: "updated existing" },
+  );
+  assert.equal((await deliver(env, messageUpdate(33, "reply", {
+    messageId: 125,
+    chatId: -1002,
+    username: "secondchannel",
+    replyToMessageId: 124,
+  }))).response.status, 204);
+  assert.equal(
+    db.row<{ reply_to: string }>("SELECT reply_to FROM messages WHERE origin_channel_id = 'xgeekshare' AND telegram_message_id = 125").reply_to,
+    "preserved-public-id",
+  );
+});
+
+test("duplicate edits preserve admin overrides and keep FTS content one-to-one", async () => {
+  const { db, env } = createTestEnv([
+    { id: "geekshare", username: "xgeekshare", chatId: "-1001" },
+    { id: "display", username: "displaychannel", chatId: "-1002" },
+  ]);
+  const original = messageUpdate(40, "telegram original #old");
+  assert.equal((await deliver(env, original)).response.status, 204);
+  assert.equal((await deliver(env, original)).response.status, 204);
+
+  const patch = await handleApi(
+    new Request("https://archive.example.com/api/admin/messages/message7", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Origin: "https://archive.example.com" },
+      body: JSON.stringify({
+        plainText: "admin body",
+        tags: ["admin"],
+        publishedAt: "2026-08-20T12:00",
+        status: "hidden",
+        channelId: "display",
+      }),
+    }),
+    env,
+  );
+  assert.equal(patch.status, 200);
+
+  const edit = messageUpdate(41, "telegram edit #new", { edited: true });
+  assert.equal((await deliver(env, edit)).response.status, 204);
+  assert.equal((await deliver(env, edit)).response.status, 204);
+  assert.equal((await deliver(env, reactionUpdate(42))).response.status, 204);
+  assert.deepEqual(
+    db.row(
+      `SELECT channel_id, html, plain_text, published_at, status, admin_override, reactions
+       FROM messages WHERE id = 'message7'`,
+    ),
+    {
+      channel_id: "display",
+      html: "admin body",
+      plain_text: "admin body",
+      published_at: 1787198400,
+      status: "hidden",
+      admin_override: 1,
+      reactions: JSON.stringify([{ emoji: "🔥", count: 3 }]),
+    },
+  );
+  assert.deepEqual(
+    db.sqlite.prepare("SELECT tag FROM message_tags WHERE message_id = 'message7'").all()
+      .map((row) => ({ ...row })),
+    [{ tag: "admin" }],
+  );
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages_fts WHERE id = 'message7'"), 1);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages_fts WHERE messages_fts MATCH 'admin body'"), 1);
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages_fts WHERE messages_fts MATCH 'telegram edit'"), 0);
+});
+
+test("missing reactions fail and later retry by composite identity while tombstones are ignored", async () => {
+  const { db, env } = createTestEnv();
+  const reaction = reactionUpdate(50);
+  assert.equal((await deliver(env, reaction)).response.status, 500);
+  assert.deepEqual(
+    db.row("SELECT status, attempt_count FROM webhook_updates WHERE update_id = '50'"),
+    { status: "failed", attempt_count: 1 },
+  );
+
+  assert.equal((await deliver(env, messageUpdate(51, "reaction target"))).response.status, 204);
+  assert.equal((await deliver(env, reaction)).response.status, 204);
+  assert.equal((await deliver(env, reaction)).response.status, 204);
+  assert.deepEqual(
+    db.row("SELECT reactions, engagement_score, plain_text FROM messages WHERE id = 'message7'"),
+    {
+      reactions: JSON.stringify([{ emoji: "🔥", count: 3 }]),
+      engagement_score: 3,
+      plain_text: "reaction target",
+    },
+  );
+  assert.deepEqual(
+    db.row("SELECT status, attempt_count FROM webhook_updates WHERE update_id = '50'"),
+    { status: "success", attempt_count: 2 },
+  );
+
+  db.sqlite.prepare(
+    `INSERT INTO message_tombstones(
+       message_id, origin_channel_id, telegram_chat_id, telegram_message_id, cleanup_status
+     ) VALUES ('deleted-999', 'geekshare', '-1001', 999, 'complete')`,
+  ).run();
+  const tombstonedReaction = reactionUpdate(52, 999);
+  assert.equal((await deliver(env, tombstonedReaction)).response.status, 204);
+  assert.equal((await deliver(env, tombstonedReaction)).response.status, 204);
+  assert.deepEqual(
+    db.row("SELECT status, channel_id, telegram_message_id, attempt_count FROM webhook_updates WHERE update_id = '52'"),
+    { status: "ignored", channel_id: "geekshare", telegram_message_id: 999, attempt_count: 1 },
+  );
+});


### PR DESCRIPTION
## Summary
- add atomic webhook lease/reclaim with attempt-generation protection
- preserve composite Telegram message identity and reliable reaction retries
- add bounded media retry, thumbnail recovery, R2 HEAD reuse, and migration 0005

## Validation
- lint: pass
- TypeScript: pass
- full release-base suite: 56/56 pass
- production build: pass
- Worker Assets: 87 verified
- Production Wrangler dry-run: pass

## Accepted residual validation risks
1. Real Telegram photo/video/document E2E was not completed.
2. Real thumbnail failure → recovery E2E was not completed.
3. Real R2 PUT → D1 failure → retry E2E was not completed.

Phase 2.4 is intentionally deferred.