### PR TITLE
首页分页、双栏对齐与详情外链按钮

### DIFF
--- a/src/app/(public)/ArchivePageClient.tsx
+++ b/src/app/(public)/ArchivePageClient.tsx
@@ -2,8 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { ArrowUp, LoaderCircle, Search, X } from "lucide-react";
-import AnimatedNumber from "@/components/AnimatedNumber";
+import { ArrowUp, ChevronLeft, ChevronRight, Search, X } from "lucide-react";
 import SiteHeader from "@/components/SiteHeader";
 import MessageCard from "@/components/MessageCard";
 import ArchiveToolbar from "@/components/home/ArchiveToolbar";
@@ -13,12 +12,13 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { ArchiveMeta, HomepageData, MessageCategory, MessageListResponse, MessageSort, PublicMessage } from "@/lib/messages";
 import { DEFAULT_PUBLIC_SITE_CONFIG, type PublicSiteConfig } from "@/lib/site-config";
+import { visiblePageNumbers } from "@/lib/utils";
 
 const categories: MessageCategory[] = ["all", "visual", "link", "interactive", "file"];
 const sorts: MessageSort[] = ["newest", "oldest", "featured", "hot"];
 const RESTORE_KEY = "geekshare:feed-position";
 
-type RestoreState = { search: string; scrollY: number; loadedCount: number };
+type RestoreState = { search: string; scrollY: number };
 
 function preferredScrollBehavior(): ScrollBehavior {
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth";
@@ -50,11 +50,9 @@ export default function ArchivePageClient() {
   const [meta, setMeta] = useState<ArchiveMeta>({ tags: [], years: [], monthsByYear: {} });
   const [homepage, setHomepage] = useState<HomepageData | null>(null);
   const [siteConfig, setSiteConfig] = useState<PublicSiteConfig>(DEFAULT_PUBLIC_SITE_CONFIG);
-  const [total, setTotal] = useState(0);
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
   const [loading, setLoading] = useState(true);
-  const [hasLoadedMessages, setHasLoadedMessages] = useState(false);
-  const [loadingMore, setLoadingMore] = useState(false);
   const [homepageLoading, setHomepageLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState(searchParams.get("q") ?? "");
@@ -69,7 +67,8 @@ export default function ArchivePageClient() {
   const activeChannel = searchParams.get("channel");
   const category = paramCategory(searchParams.get("category"));
   const sort = paramSort(searchParams.get("sort"));
-  const legacyPage = Math.max(1, Number.parseInt(searchParams.get("page") ?? "1", 10) || 1);
+  const pageParam = searchParams.get("page");
+  const requestedPage = Math.max(1, Number.parseInt(pageParam ?? "1", 10) || 1);
   const filterKey = searchParams.toString();
   const discoveryVisible = !query && !activeTag && !activeYear && !activeMonth && !activeChannel && category === "all" && sort === "newest";
 
@@ -104,15 +103,15 @@ export default function ArchivePageClient() {
   }, []);
 
   const buildParams = useCallback(() => {
-    const params = new URLSearchParams({ category, sort, limit: String(Math.min(60, Math.max(30, restoreState?.loadedCount ?? 30))) });
-    if (legacyPage > 1) params.set("page", String(legacyPage));
+    const params = new URLSearchParams({ category, sort, limit: "10" });
+    if (requestedPage > 1) params.set("page", String(requestedPage));
     if (query) params.set("q", query);
     if (activeTag) params.set("tag", activeTag);
     if (activeYear) params.set("year", activeYear);
     if (activeMonth) params.set("month", activeMonth);
     if (activeChannel) params.set("channel", activeChannel);
     return params;
-  }, [activeChannel, activeMonth, activeTag, activeYear, category, legacyPage, query, restoreState?.loadedCount, sort]);
+  }, [activeChannel, activeMonth, activeTag, activeYear, category, query, requestedPage, sort]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -125,9 +124,16 @@ export default function ArchivePageClient() {
       })
       .then((data) => {
         setMessages(data.items);
-        setTotal(data.total);
-        setNextCursor(data.nextCursor);
-        setHasLoadedMessages(true);
+        setCurrentPage(data.page);
+        setTotalPages(data.totalPages);
+        const canonicalPageParam = data.page > 1 ? String(data.page) : null;
+        if (pageParam !== canonicalPageParam) {
+          const next = new URLSearchParams(filterKey);
+          if (canonicalPageParam) next.set("page", canonicalPageParam);
+          else next.delete("page");
+          const suffix = next.toString();
+          router.replace(suffix ? `/?${suffix}` : "/", { scroll: false });
+        }
         if (restoreState && !restoredRef.current) {
           restoredRef.current = true;
           window.requestAnimationFrame(() => window.requestAnimationFrame(() => window.scrollTo({ top: restoreState.scrollY, behavior: "auto" })));
@@ -139,7 +145,7 @@ export default function ArchivePageClient() {
       })
       .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => controller.abort();
-  }, [buildParams, filterKey, restoreState]);
+  }, [buildParams, filterKey, pageParam, restoreState, router]);
 
   useEffect(() => {
     const handleScroll = () => setIsScrolled(window.scrollY > 520);
@@ -148,13 +154,23 @@ export default function ArchivePageClient() {
   }, []);
 
   const rememberPosition = useCallback(() => {
-    sessionStorage.setItem(RESTORE_KEY, JSON.stringify({ search: window.location.search, scrollY: window.scrollY, loadedCount: messages.length } satisfies RestoreState));
-  }, [messages.length]);
+    sessionStorage.setItem(RESTORE_KEY, JSON.stringify({ search: window.location.search, scrollY: window.scrollY } satisfies RestoreState));
+  }, []);
 
   const scrollToFeed = useCallback(() => {
     const y = (feedRef.current?.getBoundingClientRect().top ?? 0) + window.scrollY - (window.innerWidth < 768 ? 176 : 120);
     window.scrollTo({ top: Math.max(0, y), behavior: preferredScrollBehavior() });
   }, []);
+
+  const changePage = useCallback((page: number) => {
+    if (page === currentPage) return;
+    const next = new URLSearchParams(searchParams.toString());
+    if (page > 1) next.set("page", String(page));
+    else next.delete("page");
+    const suffix = next.toString();
+    router.push(suffix ? `/?${suffix}` : "/", { scroll: false });
+    window.setTimeout(scrollToFeed, 40);
+  }, [currentPage, router, scrollToFeed, searchParams]);
 
   const selectTag = useCallback((tag: string) => {
     updateParams({ tag: activeTag === tag ? null : tag });
@@ -171,46 +187,24 @@ export default function ArchivePageClient() {
     document.getElementById(replyId)?.scrollIntoView({ behavior: preferredScrollBehavior(), block: "center" });
   }, [messageIds, rememberPosition]);
 
-  const loadMore = async () => {
-    if (!nextCursor || loadingMore) return;
-    setLoadingMore(true);
-    try {
-      const params = buildParams();
-      params.delete("page");
-      params.set("limit", "30");
-      params.set("cursor", nextCursor);
-      const response = await fetch(`/api/messages?${params}`, { cache: "no-store" });
-      if (!response.ok) throw new Error("load more failed");
-      const data = await response.json() as MessageListResponse;
-      setMessages((current) => {
-        const known = new Set(current.map((item) => item.id));
-        return [...current, ...data.items.filter((item) => !known.has(item.id))];
-      });
-      setNextCursor(data.nextCursor);
-    } catch {
-      setLoadError("加载更多失败，请稍后重试。");
-    } finally {
-      setLoadingMore(false);
-    }
-  };
-
   const clearAll = () => updateParams({ q: null, tag: null, year: null, month: null, channel: null, category: null, sort: null });
   const filtersActive = !discoveryVisible;
   const telegramUrl = homepage?.channels.find((channel) => channel.enabled)?.telegramUrl ?? homepage?.channels[0]?.telegramUrl;
+  const pageNumbers = visiblePageNumbers(currentPage, totalPages);
 
   return (
     <div className="min-h-screen bg-[radial-gradient(circle_at_50%_-15%,rgba(59,130,246,0.06),transparent_30%)]">
       <SiteHeader searchValue={searchQuery} onSearchChange={setSearchQuery} onSearchSubmit={(value) => updateParams({ q: value.trim() })} branding={siteConfig.branding} telegramUrl={telegramUrl} />
 
-      <main className="mx-auto max-w-[1276px] px-4 pb-20 pt-3 sm:pt-5 min-[1300px]:px-0">
+      <main className="mx-auto max-w-[1120px] px-4 pb-20 pt-3 sm:pt-5">
         <h1 className="sr-only">{siteConfig.branding.siteName}归档</h1>
         <div className="space-y-3 sm:space-y-4">
           <div id="channel"><ChannelStrip data={homepage} loading={homepageLoading} activeChannel={activeChannel} onChannelChange={(channelId) => updateParams({ channel: channelId })} /></div>
           {discoveryVisible && <DiscoverySpotlight data={homepage} loading={homepageLoading} onOpenMessage={rememberPosition} />}
         </div>
 
-        <div className="mt-4 grid items-start gap-5 lg:grid-cols-[minmax(0,1fr)_320px] lg:gap-7">
-          <section id="feed" ref={feedRef} className="min-h-[60vh] scroll-mt-40 md:scroll-mt-28" aria-label="最新内容">
+        <div className="mt-4 grid items-start gap-6 lg:grid-cols-[minmax(0,1fr)_300px]">
+          <section id="feed" ref={feedRef} className="min-w-0 min-h-[60vh] scroll-mt-40 md:scroll-mt-28" aria-label="最新内容">
             <div className="sticky top-[116px] z-40 -mx-1 bg-background/92 px-1 py-2 backdrop-blur md:top-[60px]">
               <ArchiveToolbar
                 category={category} sort={sort} tags={meta.tags} years={meta.years} monthsByYear={meta.monthsByYear}
@@ -224,19 +218,7 @@ export default function ArchivePageClient() {
               />
             </div>
 
-            <div className="mb-3 flex min-h-8 items-end justify-between gap-3 px-1">
-              <div>
-                <h2 className="text-lg font-extrabold">{sort === "hot" ? "本周热门" : sort === "featured" ? "编辑精选" : sort === "oldest" ? "从最早开始" : "最新内容"}</h2>
-                {hasLoadedMessages ? (
-                  <p className={`mt-0.5 text-xs text-muted-foreground transition-opacity motion-reduce:transition-none ${loading ? "opacity-55" : "opacity-100"}`} aria-busy={loading} aria-live="polite">
-                    共 <AnimatedNumber value={total} /> 条内容
-                  </p>
-                ) : loading ? (
-                  <Skeleton className="mt-1 h-3 w-20" />
-                ) : null}
-              </div>
-              {filtersActive && <Button variant="ghost" size="sm" onClick={clearAll} className="text-muted-foreground"><X />清除条件</Button>}
-            </div>
+            {filtersActive && <div className="mb-3 flex justify-end px-1"><Button variant="ghost" size="sm" onClick={clearAll} className="text-muted-foreground"><X />清除条件</Button></div>}
 
             {loadError && messages.length === 0 ? (
               <div className="rounded-xl border bg-card py-24 text-center text-sm text-destructive">{loadError}</div>
@@ -255,10 +237,24 @@ export default function ArchivePageClient() {
               </div>
             )}
 
-            {messages.length > 0 && nextCursor && (
-              <div className="mt-5 flex justify-center">
-                <Button variant="outline" className="min-w-36" onClick={() => void loadMore()} disabled={loadingMore}>{loadingMore ? <><LoaderCircle className="animate-spin" />加载中</> : "加载更多"}</Button>
-              </div>
+            {!loading && messages.length > 0 && totalPages > 1 && (
+              <nav aria-label="内容分页" className="mt-6 flex items-center justify-center gap-1">
+                <Button variant="outline" size="icon" aria-label="上一页" disabled={currentPage <= 1} onClick={() => changePage(currentPage - 1)}><ChevronLeft /></Button>
+                {pageNumbers.map((page) => (
+                  <Button
+                    key={page}
+                    variant={page === currentPage ? "default" : "outline"}
+                    size="icon"
+                    aria-label={`第 ${page} 页`}
+                    aria-current={page === currentPage ? "page" : undefined}
+                    className="tabular-nums"
+                    onClick={() => changePage(page)}
+                  >
+                    {page}
+                  </Button>
+                ))}
+                <Button variant="outline" size="icon" aria-label="下一页" disabled={currentPage >= totalPages} onClick={() => changePage(currentPage + 1)}><ChevronRight /></Button>
+              </nav>
             )}
             {loadError && messages.length > 0 && <p className="mt-3 text-center text-sm text-destructive">{loadError}</p>}
           </section>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -137,6 +137,7 @@ body {
   background: hsl(var(--background));
   font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   min-width: 320px;
+  overflow-x: clip;
 }
 
 .site-header {

--- a/src/components/MessageCard.tsx
+++ b/src/components/MessageCard.tsx
@@ -214,6 +214,7 @@ export default function MessageCard({ message, mode = "feed", onScrollToReply, o
   const initial = message.channel.title?.charAt(0) || message.from?.charAt(0) || "极";
   const richTitle = message.titleHtml?.trim();
   const richTitleClassName = "break-words";
+  const titleUrlLabel = message.titleUrl ? titleLinkLabel(message.titleUrl) : null;
 
   const copyLink = async () => {
     try {
@@ -256,24 +257,26 @@ export default function MessageCard({ message, mode = "feed", onScrollToReply, o
 
       <div className="mt-3 sm:mt-4">
         {detail ? (
-          <>
-            <h1 className="text-balance text-2xl font-extrabold leading-[1.32] tracking-[-0.02em] sm:text-[2rem]">
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
+            <h1 className="min-w-0 text-balance text-2xl font-extrabold leading-[1.32] tracking-[-0.02em] sm:text-[2rem]">
               {richTitle
                 ? <span className={richTitleClassName} dangerouslySetInnerHTML={{ __html: richTitle }} />
                 : message.title}
             </h1>
-            {message.titleUrl && (
-              <a
-                href={message.titleUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="mt-2 inline-flex min-h-11 max-w-full items-center gap-1.5 rounded-md text-sm font-semibold text-blue-600 underline-offset-4 transition hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-blue-300"
-              >
-                <span className="truncate">打开原标题链接 · {titleLinkLabel(message.titleUrl)}</span>
-                <ExternalLink className="size-3.5 shrink-0" />
-              </a>
+            {message.titleUrl && titleUrlLabel && (
+              <Button asChild variant="outline" size="sm" className="mt-0.5 max-w-40 shrink-0 px-2.5 text-blue-600 dark:text-blue-300">
+                <a
+                  href={message.titleUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`打开原标题链接：${titleUrlLabel}`}
+                >
+                  <span className="truncate">{titleUrlLabel}</span>
+                  <ExternalLink />
+                </a>
+              </Button>
             )}
-          </>
+          </div>
         ) : (
           <h2 className="text-balance text-lg font-extrabold leading-[1.4] tracking-[-0.01em] sm:text-xl">
             {richTitle ? (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,11 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function visiblePageNumbers(page: number, totalPages: number): number[] {
+  const total = Math.max(1, Math.floor(totalPages));
+  const current = Math.min(total, Math.max(1, Math.floor(page)));
+  const count = Math.min(5, total);
+  const start = Math.min(Math.max(1, current - 2), total - count + 1);
+  return Array.from({ length: count }, (_, index) => start + index);
+}

--- a/tests/message-card.test.ts
+++ b/tests/message-card.test.ts
@@ -90,7 +90,9 @@ test("detail cards keep the same content order without clamping or summary dupli
   assert.doesNotMatch(html, /这段摘要不应出现在帖子卡片中/);
   assert.doesNotMatch(html, /<h1[^>]*>\s*<a/);
   assert.match(html, /href="https:\/\/github\.com\/iAmCorey\/Wake"[^>]*target="_blank"[^>]*rel="noopener noreferrer"/);
-  assert.match(html, /打开原标题链接 · github\.com/);
+  assert.match(html, /aria-label="打开原标题链接：github\.com"/);
+  assert.match(html, />github\.com<\/span>/);
+  assert.doesNotMatch(html, /打开原标题链接 ·/);
 });
 
 test("detail cards omit the original-title action when no title link exists", () => {
@@ -99,5 +101,5 @@ test("detail cards omit the original-title action when no title link exists", ()
     mode: "detail",
   }));
 
-  assert.doesNotMatch(html, /打开原标题链接/);
+  assert.doesNotMatch(html, /aria-label="打开原标题链接：/);
 });

--- a/tests/public-query.test.ts
+++ b/tests/public-query.test.ts
@@ -10,6 +10,7 @@ import {
   parseMessageCursor,
   parseMessageSort,
 } from "../src/cloudflare/public-query";
+import { visiblePageNumbers } from "../src/lib/utils";
 
 test("public list options only accept documented categories and sort orders", () => {
   assert.equal(parseMessageCategory(null), "all");
@@ -30,6 +31,15 @@ test("message cursors round-trip and reject malformed state", () => {
   assert.deepEqual(parseMessageCursor(encodeMessageCursor(cursor)), cursor);
   assert.equal(parseMessageCursor(null), null);
   assert.equal(parseMessageCursor("not-a-cursor"), undefined);
+});
+
+test("pagination shows at most five consecutive normalized page numbers", () => {
+  assert.deepEqual(visiblePageNumbers(1, 2), [1, 2]);
+  assert.deepEqual(visiblePageNumbers(1, 9), [1, 2, 3, 4, 5]);
+  assert.deepEqual(visiblePageNumbers(5, 9), [3, 4, 5, 6, 7]);
+  assert.deepEqual(visiblePageNumbers(9, 9), [5, 6, 7, 8, 9]);
+  assert.deepEqual(visiblePageNumbers(99, 9), [5, 6, 7, 8, 9]);
+  assert.deepEqual(visiblePageNumbers(-5, 9), [1, 2, 3, 4, 5]);
 });
 
 test("message categories map to their stored message signals", () => {


### PR DESCRIPTION
## 变更
- 首页双栏宽度与消息详情页一致
- 移除首页内容总数区域并添加 10 条/页的页码分页
- 将原标题链接改为标题右侧域名按钮
- 修复 320px 窄屏横向滚动

## 验证
- 60 项测试通过
- lint、typecheck、production build 通过
- 布局检测无异常