### PR TITLE
feat: support Telegram rich messages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -308,6 +308,194 @@ textarea {
     white-space: pre;
   }
 
+  .message-reading-body .tg-rich-heading {
+    color: hsl(var(--foreground));
+    font-weight: 750;
+  }
+
+  .message-reading-body .tg-rich-heading-1 {
+    font-size: 1.25em;
+  }
+
+  .message-reading-body .tg-rich-heading-2,
+  .message-reading-body .tg-rich-heading-3 {
+    font-size: 1.125em;
+  }
+
+  .message-reading-body .tg-rich-list {
+    margin-block: 0.75rem;
+    padding-left: 1.5rem;
+  }
+
+  .message-reading-body ul.tg-rich-list {
+    list-style: disc;
+  }
+
+  .message-reading-body ol.tg-rich-list {
+    list-style: decimal;
+  }
+
+  .message-reading-body .tg-rich-list li + li {
+    margin-top: 0.25rem;
+  }
+
+  .message-reading-body .tg-rich-block-break {
+    display: block;
+    height: 0.45rem;
+  }
+
+  .message-reading-body .tg-rich-checkbox {
+    display: inline-block;
+    margin-right: 0.45rem;
+  }
+
+  .message-reading-body blockquote {
+    margin-block: 0.875rem;
+    border-left: 3px solid hsl(var(--primary));
+    border-radius: 0 0.5rem 0.5rem 0;
+    background: hsl(var(--muted) / 0.55);
+    padding: 0.6rem 0.875rem;
+  }
+
+  .message-reading-body blockquote footer,
+  .message-reading-body .tg-rich-footer,
+  .message-reading-body .tg-rich-caption {
+    color: hsl(var(--muted-foreground));
+    font-size: 0.875em;
+  }
+
+  .message-reading-body .tg-rich-pullquote {
+    border-inline: 0;
+    border-block: 1px solid hsl(var(--border));
+    border-radius: 0;
+    background: transparent;
+    text-align: center;
+  }
+
+  .message-reading-body .tg-rich-divider {
+    margin-block: 1rem;
+    border: 0;
+    border-top: 1px solid hsl(var(--border));
+  }
+
+  .message-reading-body mark {
+    border-radius: 0.2em;
+    background: hsl(48 96% 70% / 0.65);
+    padding-inline: 0.12em;
+    color: inherit;
+  }
+
+  .message-reading-body details {
+    margin-block: 0.875rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: 0.65rem;
+    background: hsl(var(--muted) / 0.35);
+    padding: 0.65rem 0.8rem;
+  }
+
+  .message-reading-body summary {
+    cursor: pointer;
+    color: hsl(var(--foreground));
+    font-weight: 650;
+  }
+
+  .message-reading-body details[open] > summary {
+    margin-bottom: 0.5rem;
+  }
+
+  .message-reading-body .tg-rich-math--block {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+    margin-block: 0.875rem;
+    white-space: pre;
+  }
+
+  .message-reading-body .tg-rich-table-scroll {
+    max-width: 100%;
+    overflow-x: auto;
+    margin-block: 1rem;
+  }
+
+  .message-reading-body .tg-rich-table {
+    width: 100%;
+    min-width: max-content;
+    border-collapse: collapse;
+    font-size: 0.9em;
+    line-height: 1.55;
+  }
+
+  .message-reading-body .tg-rich-table caption {
+    margin-bottom: 0.5rem;
+    color: hsl(var(--muted-foreground));
+    text-align: left;
+  }
+
+  .message-reading-body .tg-rich-table th,
+  .message-reading-body .tg-rich-table td {
+    border-bottom: 1px solid hsl(var(--border));
+    padding: 0.5rem 0.7rem;
+    text-align: left;
+  }
+
+  .message-reading-body .tg-rich-table th {
+    background: hsl(var(--muted) / 0.6);
+    color: hsl(var(--foreground));
+    font-weight: 700;
+  }
+
+  .message-reading-body .tg-rich-table.is-bordered th,
+  .message-reading-body .tg-rich-table.is-bordered td {
+    border: 1px solid hsl(var(--border));
+  }
+
+  .message-reading-body .tg-rich-table.is-striped tr:nth-child(even) td {
+    background: hsl(var(--muted) / 0.35);
+  }
+
+  .message-reading-body .tg-rich-table.is-compact th,
+  .message-reading-body .tg-rich-table.is-compact td {
+    padding: 0.3rem 0.5rem;
+  }
+
+  .message-reading-body .tg-align-center {
+    text-align: center !important;
+  }
+
+  .message-reading-body .tg-align-right {
+    text-align: right !important;
+  }
+
+  .message-reading-body .tg-valign-middle {
+    vertical-align: middle;
+  }
+
+  .message-reading-body .tg-valign-top {
+    vertical-align: top;
+  }
+
+  .message-reading-body .tg-valign-bottom {
+    vertical-align: bottom;
+  }
+
+  .message-reading-body .tg-rich-button-row {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .message-reading-body .tg-rich-button {
+    display: inline-flex;
+    border: 1px solid hsl(var(--border));
+    border-radius: 0.5rem;
+    padding: 0.2rem 0.65rem;
+    text-decoration: none;
+  }
+
+  .message-reading-body .tg-rich-button--inactive {
+    color: hsl(var(--muted-foreground));
+  }
+
   .message-reading-body img,
   .message-reading-body video {
     max-width: 100%;

--- a/src/cloudflare/api.ts
+++ b/src/cloudflare/api.ts
@@ -60,12 +60,11 @@ import {
   archiveBotFile,
   extractTags,
   MediaArchiveError,
-  messageMedia,
   secretsMatch,
   shanghaiDate,
   stableMessageId,
   telegramApi,
-  telegramTextToHtml,
+  telegramMessageContent,
   type TelegramMessage,
   type TelegramReactionUpdate,
   type TelegramUpdate,
@@ -604,10 +603,9 @@ async function persistMessage(
     .bind(channel.id, message.message_id)
     .first<{ id: string; admin_override: number }>();
   const id = existing?.id ?? stableMessageId(channel.id, message.message_id);
-  const text = message.text ?? message.caption ?? "";
-  const entities = message.entities ?? message.caption_entities ?? [];
+  const content = telegramMessageContent(message);
   const time = shanghaiDate(message.date);
-  const media = messageMedia(message);
+  const media = content.media;
   const archiveStatus = media.length ? "pending" : "none";
   const replyTarget = message.reply_to_message
     ? await env.DB.prepare(
@@ -621,7 +619,7 @@ async function persistMessage(
     ? replyTarget?.id ?? stableMessageId(channel.id, message.reply_to_message.message_id)
     : null;
   const sourceUrl = `https://t.me/${channel.username}/${message.message_id}`;
-  const tags = extractTags(text);
+  const tags = extractTags(content.plainText);
   const statements = [
     env.DB.prepare(
       `INSERT INTO messages (
@@ -663,8 +661,8 @@ async function persistMessage(
       time.year,
       time.month,
       message.sender_chat?.title ?? message.chat.title ?? channel.title,
-      telegramTextToHtml(text, entities),
-      text,
+      content.html,
+      content.plainText,
       JSON.stringify(media),
       replyTo,
       JSON.stringify(update),
@@ -1403,7 +1401,7 @@ async function prepareMessageMediaRetry(
   const update = safeJsonParse<TelegramUpdate | null>(row.raw_payload, null);
   const message = update?.channel_post ?? update?.edited_channel_post;
   const storedMedia = safeJsonParse<StoredMedia[]>(row.media, []);
-  const media = storedMedia.length ? storedMedia : message ? messageMedia(message) : [];
+  const media = storedMedia.length ? storedMedia : message ? telegramMessageContent(message).media : [];
   if (!media.length) {
     return { ok: false, status: 409, error: "Message has no retryable Telegram media" };
   }

--- a/src/cloudflare/telegram.ts
+++ b/src/cloudflare/telegram.ts
@@ -21,6 +21,85 @@ export interface TelegramFileRef {
   thumbnail?: TelegramFileRef;
 }
 
+export type TelegramRichText =
+  | string
+  | TelegramRichText[]
+  | {
+      type: string;
+      text?: TelegramRichText;
+      alternative_text?: string;
+      expression?: string;
+      url?: string;
+      email_address?: string;
+      phone_number?: string;
+      username?: string;
+      anchor_name?: string;
+      reference_name?: string;
+      name?: string;
+      user?: { id: number | string };
+      button?: TelegramRichMessageButton;
+    };
+
+export interface TelegramRichMessageButton {
+  text: TelegramRichText;
+  url?: string;
+  web_app?: { url?: string };
+  login_url?: { url?: string };
+  disabled?: unknown;
+}
+
+export interface TelegramRichBlockCaption {
+  text: TelegramRichText;
+  credit?: TelegramRichText;
+}
+
+export interface TelegramRichBlock {
+  type: string;
+  text?: TelegramRichText;
+  credit?: TelegramRichText;
+  summary?: TelegramRichText;
+  caption?: TelegramRichBlockCaption | TelegramRichText;
+  expression?: string;
+  language?: string;
+  name?: string;
+  size?: number;
+  is_open?: boolean;
+  is_bordered?: boolean;
+  is_striped?: boolean;
+  is_compact?: boolean;
+  blocks?: TelegramRichBlock[];
+  items?: Array<{
+    label?: string;
+    blocks?: TelegramRichBlock[];
+    has_checkbox?: boolean;
+    is_checked?: boolean;
+    value?: number;
+    type?: string;
+  }>;
+  cells?: Array<Array<{
+    text?: TelegramRichText;
+    is_header?: boolean;
+    colspan?: number;
+    rowspan?: number;
+    align?: string;
+    valign?: string;
+  }>>;
+  buttons?: TelegramRichMessageButton[];
+  location?: { latitude?: number; longitude?: number };
+  zoom?: number;
+  animation?: TelegramFileRef;
+  audio?: TelegramFileRef;
+  document?: TelegramFileRef;
+  photo?: TelegramFileRef[];
+  video?: TelegramFileRef;
+  voice_note?: TelegramFileRef;
+}
+
+export interface TelegramRichMessage {
+  blocks: TelegramRichBlock[];
+  is_rtl?: boolean;
+}
+
 export interface TelegramMessage {
   message_id: number;
   date: number;
@@ -40,6 +119,7 @@ export interface TelegramMessage {
   voice?: TelegramFileRef;
   video_note?: TelegramFileRef;
   sticker?: TelegramFileRef;
+  rich_message?: TelegramRichMessage;
 }
 
 export interface TelegramReactionUpdate {
@@ -82,7 +162,7 @@ function escapeHtml(value: string): string {
 function safeHref(value: string): string | null {
   try {
     const url = new URL(value);
-    return ["http:", "https:", "tg:", "mailto:"].includes(url.protocol)
+    return ["http:", "https:", "tg:", "mailto:", "tel:"].includes(url.protocol)
       ? url.toString()
       : null;
   } catch {
@@ -152,6 +232,379 @@ export function telegramTextToHtml(
   return html.replaceAll("\n", "<br>");
 }
 
+type RenderedRichContent = {
+  html: string;
+  text: string;
+  media: StoredMedia[];
+};
+
+export type TelegramMessageContent = {
+  html: string;
+  plainText: string;
+  media: StoredMedia[];
+};
+
+const MAX_RICH_DEPTH = 32;
+
+function rendered(html = "", text = "", media: StoredMedia[] = []): RenderedRichContent {
+  return { html, text, media };
+}
+
+function safeAnchorName(value: string | undefined): string | null {
+  const normalized = value?.trim().replace(/[^\p{L}\p{N}_-]+/gu, "-").slice(0, 80);
+  return normalized ? `tg-${normalized}` : null;
+}
+
+function wrapInline(tag: string, content: RenderedRichContent, attributes = ""): RenderedRichContent {
+  if (!content.html && !content.text) return content;
+  return rendered(`<${tag}${attributes}>${content.html}</${tag}>`, content.text, content.media);
+}
+
+function safeLink(content: RenderedRichContent, href: string | undefined, className = ""): RenderedRichContent {
+  const safe = href ? safeHref(href) : null;
+  if (!safe || !content.html) return content;
+  const classes = className ? ` class="${className}"` : "";
+  return rendered(
+    `<a href="${escapeHtml(safe)}" rel="noopener noreferrer"${classes}>${content.html}</a>`,
+    content.text,
+    content.media,
+  );
+}
+
+function renderRichButton(button: TelegramRichMessageButton | undefined, depth: number): RenderedRichContent {
+  if (!button) return rendered();
+  const label = renderRichText(button.text, depth + 1);
+  const href = button.url ?? button.web_app?.url ?? button.login_url?.url;
+  const linked = safeLink(label, href, "tg-rich-button");
+  return linked === label
+    ? wrapInline("span", label, ' class="tg-rich-button tg-rich-button--inactive"')
+    : linked;
+}
+
+function renderRichText(value: TelegramRichText | undefined, depth = 0): RenderedRichContent {
+  if (depth > MAX_RICH_DEPTH || value === undefined || value === null) return rendered();
+  if (typeof value === "string") {
+    const text = value.replace(/\r\n?/g, "\n");
+    return rendered(escapeHtml(text).replaceAll("\n", "<br>"), text);
+  }
+  if (Array.isArray(value)) {
+    const parts = value.map((part) => renderRichText(part, depth + 1));
+    return rendered(
+      parts.map((part) => part.html).join(""),
+      parts.map((part) => part.text).join(""),
+      parts.flatMap((part) => part.media),
+    );
+  }
+  if (typeof value !== "object") return rendered();
+
+  const inner = renderRichText(value.text, depth + 1);
+  switch (value.type) {
+    case "bold":
+      return wrapInline("strong", inner);
+    case "italic":
+      return wrapInline("em", inner);
+    case "underline":
+      return wrapInline("u", inner);
+    case "strikethrough":
+      return wrapInline("s", inner);
+    case "spoiler":
+      return wrapInline("span", inner, ' class="tg-spoiler"');
+    case "subscript":
+      return wrapInline("sub", inner);
+    case "superscript":
+      return wrapInline("sup", inner);
+    case "marked":
+      return wrapInline("mark", inner);
+    case "code":
+      return wrapInline("code", inner);
+    case "url":
+      return safeLink(inner, value.url);
+    case "email_address":
+      return safeLink(inner, value.email_address ? `mailto:${value.email_address}` : undefined);
+    case "phone_number":
+      return safeLink(inner, value.phone_number ? `tel:${value.phone_number}` : undefined);
+    case "text_mention":
+      return safeLink(inner, value.user?.id === undefined ? undefined : `tg://user?id=${value.user.id}`);
+    case "mention":
+      return safeLink(
+        inner,
+        value.username && /^[a-z0-9_]{5,32}$/i.test(value.username)
+          ? `https://t.me/${value.username}`
+          : undefined,
+      );
+    case "custom_emoji": {
+      const text = value.alternative_text ?? "";
+      return rendered(escapeHtml(text), text);
+    }
+    case "mathematical_expression": {
+      const text = value.expression ?? "";
+      return rendered(`<code class="tg-rich-math">${escapeHtml(text)}</code>`, text);
+    }
+    case "button":
+      return renderRichButton(value.button, depth + 1);
+    case "anchor": {
+      const id = safeAnchorName(value.name);
+      return id ? rendered(`<span id="${escapeHtml(id)}"></span>`) : rendered();
+    }
+    case "anchor_link": {
+      const id = safeAnchorName(value.anchor_name);
+      return id && inner.html
+        ? rendered(`<a href="#${escapeHtml(id)}">${inner.html}</a>`, inner.text)
+        : inner;
+    }
+    case "reference": {
+      const id = safeAnchorName(value.name);
+      return id ? wrapInline("span", inner, ` id="${escapeHtml(id)}"`) : inner;
+    }
+    case "reference_link": {
+      const id = safeAnchorName(value.reference_name);
+      return id && inner.html
+        ? rendered(`<a href="#${escapeHtml(id)}">${inner.html}</a>`, inner.text)
+        : inner;
+    }
+    default:
+      if (value.text !== undefined) return inner;
+      if (value.alternative_text) return rendered(escapeHtml(value.alternative_text), value.alternative_text);
+      if (value.expression) return rendered(escapeHtml(value.expression), value.expression);
+      return rendered();
+  }
+}
+
+function renderCaption(
+  caption: TelegramRichBlockCaption | TelegramRichText | undefined,
+  depth: number,
+): RenderedRichContent {
+  if (caption === undefined) return rendered();
+  if (
+    caption
+    && typeof caption === "object"
+    && !Array.isArray(caption)
+    && !("type" in caption)
+    && "text" in caption
+  ) {
+    const content = renderRichText(caption.text, depth + 1);
+    const credit = renderRichText(caption.credit, depth + 1);
+    const html = [content.html, credit.html ? `<cite>${credit.html}</cite>` : ""].filter(Boolean).join(" ");
+    const text = [content.text, credit.text].filter(Boolean).join(" — ");
+    return rendered(html ? `<span class="tg-rich-caption">${html}</span>` : "", text);
+  }
+  const content = renderRichText(caption as TelegramRichText, depth + 1);
+  return wrapInline("span", content, ' class="tg-rich-caption"');
+}
+
+function mediaFromFile(
+  type: StoredMedia["type"],
+  file: TelegramFileRef | undefined,
+  description?: string,
+): StoredMedia[] {
+  if (!file) return [];
+  return [{
+    type,
+    mimeType: file.mime_type,
+    size: file.file_size,
+    title: file.file_name,
+    description: description || undefined,
+    archiveStatus: "pending",
+    fileId: file.file_id,
+    fileUniqueId: file.file_unique_id,
+    fileName: file.file_name,
+    thumbFileId: file.thumbnail?.file_id,
+    thumbFileUniqueId: file.thumbnail?.file_unique_id,
+    thumbSize: file.thumbnail?.file_size,
+    thumbMimeType: file.thumbnail?.mime_type,
+  }];
+}
+
+function renderRichBlocks(
+  blocks: TelegramRichBlock[] | undefined,
+  depth: number,
+  topLevel = false,
+): RenderedRichContent {
+  if (depth > MAX_RICH_DEPTH || !Array.isArray(blocks)) return rendered();
+  const parts = blocks.map((block) => renderRichBlock(block, depth + 1));
+  return rendered(
+    parts.filter((part) => part.html).map((part) => part.html).join(
+      topLevel ? "<br>" : '<span class="tg-rich-block-break"></span>',
+    ),
+    parts.filter((part) => part.text).map((part) => part.text).join("\n"),
+    parts.flatMap((part) => part.media),
+  );
+}
+
+function renderRichBlock(block: TelegramRichBlock, depth: number): RenderedRichContent {
+  if (depth > MAX_RICH_DEPTH || !block || typeof block !== "object") return rendered();
+  const inline = () => renderRichText(block.text, depth + 1);
+  const credit = () => renderRichText(block.credit, depth + 1);
+  const caption = () => renderCaption(block.caption, depth + 1);
+  const nested = () => renderRichBlocks(block.blocks, depth + 1);
+
+  switch (block.type) {
+    case "paragraph":
+      return inline();
+    case "heading": {
+      const size = Math.min(6, Math.max(1, Number(block.size) || 2));
+      return wrapInline("span", inline(), ` class="tg-rich-heading tg-rich-heading-${size}"`);
+    }
+    case "pre": {
+      const content = inline();
+      const language = block.language?.trim().slice(0, 40);
+      const attribute = language ? ` data-language="${escapeHtml(language)}"` : "";
+      return rendered(`<pre><code${attribute}>${escapeHtml(content.text)}</code></pre>`, content.text);
+    }
+    case "footer":
+      return wrapInline("small", inline(), ' class="tg-rich-footer"');
+    case "divider":
+      return rendered('<hr class="tg-rich-divider">');
+    case "mathematical_expression": {
+      const expression = block.expression ?? "";
+      return rendered(`<code class="tg-rich-math tg-rich-math--block">${escapeHtml(expression)}</code>`, expression);
+    }
+    case "anchor": {
+      const id = safeAnchorName(block.name);
+      return id ? rendered(`<span id="${escapeHtml(id)}"></span>`) : rendered();
+    }
+    case "list": {
+      const items = Array.isArray(block.items) ? block.items : [];
+      const ordered = items.some((item) => Number.isInteger(item.value) || ["1", "a", "A", "i", "I"].includes(item.type ?? ""));
+      const tag = ordered ? "ol" : "ul";
+      const listType = ordered ? items.find((item) => ["1", "a", "A", "i", "I"].includes(item.type ?? ""))?.type : undefined;
+      const renderedItems = items.map((item, index) => {
+        const content = renderRichBlocks(item.blocks, depth + 1);
+        const checkbox = item.has_checkbox ? (item.is_checked ? "☑" : "☐") : "";
+        const value = ordered && Number.isInteger(item.value) ? ` value="${Math.max(1, Number(item.value))}"` : "";
+        const html = `<li${value}>${checkbox ? `<span class="tg-rich-checkbox" aria-hidden="true">${checkbox}</span>` : ""}${content.html}</li>`;
+        const label = checkbox || item.label?.trim() || (ordered ? `${item.value ?? index + 1}.` : "•");
+        return rendered(html, `${label} ${content.text}`.trim(), content.media);
+      });
+      const typeAttribute = listType ? ` type="${listType}"` : "";
+      return rendered(
+        `<${tag} class="tg-rich-list"${typeAttribute}>${renderedItems.map((item) => item.html).join("")}</${tag}>`,
+        renderedItems.map((item) => item.text).join("\n"),
+        renderedItems.flatMap((item) => item.media),
+      );
+    }
+    case "blockquote": {
+      const content = nested();
+      const attribution = credit();
+      return rendered(
+        `<blockquote>${content.html}${attribution.html ? `<footer>${attribution.html}</footer>` : ""}</blockquote>`,
+        content.text.split("\n").map((line) => `> ${line}`).join("\n") + (attribution.text ? `\n— ${attribution.text}` : ""),
+        content.media,
+      );
+    }
+    case "expandable_blockquote": {
+      const content = inline();
+      const attribution = credit();
+      return rendered(
+        `<details class="tg-rich-quote"><summary>展开引用</summary><blockquote>${content.html}${attribution.html ? `<footer>${attribution.html}</footer>` : ""}</blockquote></details>`,
+        `${content.text}${attribution.text ? `\n— ${attribution.text}` : ""}`,
+      );
+    }
+    case "pullquote": {
+      const content = inline();
+      const attribution = credit();
+      return rendered(
+        `<blockquote class="tg-rich-pullquote">${content.html}${attribution.html ? `<footer>${attribution.html}</footer>` : ""}</blockquote>`,
+        `${content.text}${attribution.text ? `\n— ${attribution.text}` : ""}`,
+      );
+    }
+    case "collage":
+    case "slideshow": {
+      const content = nested();
+      const note = caption();
+      return rendered(
+        [content.html, note.html].filter(Boolean).join("<br>"),
+        [content.text, note.text].filter(Boolean).join("\n"),
+        content.media,
+      );
+    }
+    case "table": {
+      const rows = Array.isArray(block.cells) ? block.cells : [];
+      const tableCaption = renderRichText(
+        typeof block.caption === "object" && block.caption && !Array.isArray(block.caption) && !("type" in block.caption) && "text" in block.caption
+          ? block.caption.text
+          : block.caption as TelegramRichText | undefined,
+        depth + 1,
+      );
+      const renderedRows = rows.map((row) => row.map((cell) => {
+        const content = renderRichText(cell.text, depth + 1);
+        const tag = cell.is_header ? "th" : "td";
+        const colspan = Number.isInteger(cell.colspan) && Number(cell.colspan) > 1 ? ` colspan="${Math.min(100, Number(cell.colspan))}"` : "";
+        const rowspan = Number.isInteger(cell.rowspan) && Number(cell.rowspan) > 1 ? ` rowspan="${Math.min(100, Number(cell.rowspan))}"` : "";
+        const align = ["left", "center", "right"].includes(cell.align ?? "") ? ` tg-align-${cell.align}` : "";
+        const valign = ["top", "middle", "bottom"].includes(cell.valign ?? "") ? ` tg-valign-${cell.valign}` : "";
+        return rendered(`<${tag} class="${`${align}${valign}`.trim()}"${colspan}${rowspan}>${content.html}</${tag}>`, content.text);
+      }));
+      const classes = ["tg-rich-table", block.is_bordered && "is-bordered", block.is_striped && "is-striped", block.is_compact && "is-compact"].filter(Boolean).join(" ");
+      const table = `<div class="tg-rich-table-scroll"><table class="${classes}">${tableCaption.html ? `<caption>${tableCaption.html}</caption>` : ""}<tbody>${renderedRows.map((row) => `<tr>${row.map((cell) => cell.html).join("")}</tr>`).join("")}</tbody></table></div>`;
+      return rendered(
+        table,
+        [tableCaption.text, ...renderedRows.map((row) => row.map((cell) => cell.text).join("\t"))].filter(Boolean).join("\n"),
+      );
+    }
+    case "details": {
+      const summary = renderRichText(block.summary, depth + 1);
+      const content = nested();
+      return rendered(
+        `<details${block.is_open ? " open" : ""}><summary>${summary.html || "详细内容"}</summary>${content.html}</details>`,
+        [summary.text, content.text].filter(Boolean).join("\n"),
+        content.media,
+      );
+    }
+    case "map": {
+      const latitude = Number(block.location?.latitude);
+      const longitude = Number(block.location?.longitude);
+      const note = caption();
+      if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return note;
+      const zoom = Math.min(19, Math.max(0, Number(block.zoom) || 14));
+      const label = `地图：${latitude.toFixed(5)}, ${longitude.toFixed(5)}`;
+      const link = safeLink(
+        rendered(escapeHtml(label), label),
+        `https://www.openstreetmap.org/?mlat=${latitude}&mlon=${longitude}#map=${zoom}/${latitude}/${longitude}`,
+      );
+      return rendered(
+        [link.html, note.html].filter(Boolean).join("<br>"),
+        [link.text, note.text].filter(Boolean).join("\n"),
+      );
+    }
+    case "buttons": {
+      const buttons = (Array.isArray(block.buttons) ? block.buttons : []).map((button) => renderRichButton(button, depth + 1));
+      return rendered(
+        `<span class="tg-rich-button-row">${buttons.map((button) => button.html).join(" ")}</span>`,
+        buttons.map((button) => button.text).filter(Boolean).join(" "),
+      );
+    }
+    case "animation":
+    case "audio":
+    case "document":
+    case "photo":
+    case "video":
+    case "voice_note": {
+      const note = caption();
+      const file = block.type === "photo"
+        ? chooseLargest(block.photo)
+        : block[block.type as "animation" | "audio" | "document" | "video" | "voice_note"];
+      const type: StoredMedia["type"] = block.type === "photo"
+        ? "photo"
+        : ["video", "animation"].includes(block.type) ? "video" : "file";
+      return rendered(note.html, note.text, mediaFromFile(type, file, note.text));
+    }
+    default: {
+      const parts = [inline(), nested(), caption(), renderRichText(block.summary, depth + 1)];
+      return rendered(
+        parts.filter((part) => part.html).map((part) => part.html).join("<br>"),
+        parts.filter((part) => part.text).map((part) => part.text).join("\n"),
+        parts.flatMap((part) => part.media),
+      );
+    }
+  }
+}
+
+function renderRichMessage(message: TelegramRichMessage): TelegramMessageContent {
+  const content = renderRichBlocks(message.blocks, 0, true);
+  return { html: content.html, plainText: content.text, media: content.media };
+}
+
 export function extractTags(text: string): string[] {
   const tags = new Set<string>();
   for (const match of text.matchAll(/(?:^|\s)#([\p{L}\p{N}_-]{1,64})/gu)) {
@@ -197,7 +650,7 @@ function chooseLargest(items: TelegramFileRef[] | undefined): TelegramFileRef | 
   }, undefined);
 }
 
-export function messageMedia(message: TelegramMessage): StoredMedia[] {
+function legacyMessageMedia(message: TelegramMessage): StoredMedia[] {
   const photo = chooseLargest(message.photo);
   const candidates: Array<{ type: StoredMedia["type"]; file?: TelegramFileRef }> = [
     { type: "photo", file: photo },
@@ -209,23 +662,26 @@ export function messageMedia(message: TelegramMessage): StoredMedia[] {
   ];
   const selected = candidates.find((candidate) => candidate.file);
   if (!selected?.file) return [];
-  const file = selected.file;
-  return [
-    {
-      type: selected.type,
-      mimeType: file.mime_type,
-      size: file.file_size,
-      title: file.file_name,
-      archiveStatus: "pending",
-      fileId: file.file_id,
-      fileUniqueId: file.file_unique_id,
-      fileName: file.file_name,
-      thumbFileId: file.thumbnail?.file_id,
-      thumbFileUniqueId: file.thumbnail?.file_unique_id,
-      thumbSize: file.thumbnail?.file_size,
-      thumbMimeType: file.thumbnail?.mime_type,
-    },
-  ];
+  return mediaFromFile(selected.type, selected.file);
+}
+
+export function messageMedia(message: TelegramMessage): StoredMedia[] {
+  return message.rich_message
+    ? renderRichMessage(message.rich_message).media
+    : legacyMessageMedia(message);
+}
+
+export function telegramMessageContent(message: TelegramMessage): TelegramMessageContent {
+  if (message.rich_message) return renderRichMessage(message.rich_message);
+  const plainText = message.text ?? message.caption ?? "";
+  const entities = message.text !== undefined
+    ? message.entities ?? []
+    : message.caption_entities ?? [];
+  return {
+    html: telegramTextToHtml(plainText, entities),
+    plainText,
+    media: legacyMessageMedia(message),
+  };
 }
 
 export async function telegramApi<T>(

--- a/tests/telegram.test.ts
+++ b/tests/telegram.test.ts
@@ -7,6 +7,7 @@ import {
   messageMedia,
   shanghaiDate,
   stableMessageId,
+  telegramMessageContent,
   telegramTextToHtml,
 } from "../src/cloudflare/telegram";
 import type { Env } from "../src/cloudflare/runtime";
@@ -27,6 +28,87 @@ test("Telegram entities become a small safe HTML subset", () => {
     ]),
     "click",
   );
+});
+
+test("Telegram rich messages become safe searchable HTML, text, and ordered media", () => {
+  const content = telegramMessageContent({
+    message_id: 8,
+    date: 0,
+    chat: { id: -1001 },
+    rich_message: {
+      blocks: [
+        {
+          type: "heading",
+          size: 1,
+          text: { type: "bold", text: ["<富文本标题>", { type: "url", text: " 官网", url: "https://example.com/docs?a=1&b=2" }] },
+        },
+        {
+          type: "paragraph",
+          text: ["正文 #Rich", { type: "url", text: " 不安全链接", url: "javascript:alert(1)" }],
+        },
+        {
+          type: "list",
+          items: [
+            { label: "•", blocks: [{ type: "paragraph", text: "第一项" }] },
+            { has_checkbox: true, is_checked: true, blocks: [{ type: "paragraph", text: { type: "code", text: "done()" } }] },
+          ],
+        },
+        {
+          type: "blockquote",
+          blocks: [{ type: "paragraph", text: { type: "italic", text: "引用" } }],
+          credit: "作者",
+        },
+        { type: "pre", language: "ts\" onclick=\"x", text: "const value = 1;\nvalue++;" },
+        {
+          type: "table",
+          is_bordered: true,
+          caption: "数据表",
+          cells: [[
+            { text: "名称", is_header: true },
+            { text: "数值", is_header: true, align: "right" },
+          ], [{ text: "A" }, { text: "1", align: "right" }]],
+        },
+        {
+          type: "details",
+          summary: "更多",
+          is_open: true,
+          blocks: [{ type: "paragraph", text: "折叠正文" }],
+        },
+        { type: "mathematical_expression", expression: "E = mc^2" },
+        {
+          type: "collage",
+          blocks: [
+            {
+              type: "photo",
+              photo: [{ file_id: "small", file_unique_id: "p1", file_size: 10 }, { file_id: "large", file_unique_id: "p2", file_size: 20 }],
+              caption: { text: "图片说明", credit: "摄影者" },
+            },
+            {
+              type: "document",
+              document: { file_id: "document", file_unique_id: "d1", file_name: "guide.pdf", mime_type: "application/pdf" },
+              caption: { text: "文件说明" },
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  assert.match(content.html, /tg-rich-heading-1/);
+  assert.match(content.html, /&lt;富文本标题&gt;/);
+  assert.match(content.html, /href="https:\/\/example\.com\/docs\?a=1&amp;b=2"/);
+  assert.doesNotMatch(content.html, /javascript:|onclick="x"/);
+  assert.match(content.html, /<ul class="tg-rich-list">/);
+  assert.match(content.html, /<blockquote>/);
+  assert.match(content.html, /<pre><code data-language="ts&quot; onclick=&quot;x">/);
+  assert.match(content.html, /tg-rich-table-scroll/);
+  assert.match(content.html, /<details open>/);
+  assert.match(content.html, /E = mc\^2/);
+  assert.match(content.plainText, /<富文本标题> 官网[\s\S]*正文 #Rich[\s\S]*第一项[\s\S]*数据表[\s\S]*折叠正文/);
+  assert.deepEqual(content.media.map((item) => ({ type: item.type, fileId: item.fileId, title: item.title, description: item.description })), [
+    { type: "photo", fileId: "large", title: undefined, description: "图片说明 — 摄影者" },
+    { type: "file", fileId: "document", title: "guide.pdf", description: "文件说明" },
+  ]);
 });
 
 test("date and stable IDs preserve existing links", () => {

--- a/tests/visual-css.test.ts
+++ b/tests/visual-css.test.ts
@@ -23,4 +23,6 @@ test("technical message content cannot widen narrow cards", () => {
   assert.match(css, /\.message-reading-body pre\s*{[\s\S]*?max-width:\s*100%/);
   assert.match(css, /\.message-reading-body pre\s*{[\s\S]*?overflow-x:\s*auto/);
   assert.match(css, /\.message-reading-body pre code\s*{[\s\S]*?white-space:\s*pre/);
+  assert.match(css, /\.message-reading-body \.tg-rich-table-scroll\s*{[\s\S]*?max-width:\s*100%[\s\S]*?overflow-x:\s*auto/);
+  assert.match(css, /\.message-reading-body \.tg-rich-math--block\s*{[\s\S]*?overflow-x:\s*auto/);
 });

--- a/tests/webhook-reliability.test.ts
+++ b/tests/webhook-reliability.test.ts
@@ -6,7 +6,55 @@ import {
   deliver,
   messageUpdate,
   reactionUpdate,
+  telegramFetch,
 } from "./cloudflare-test-helpers";
+import type { TelegramUpdate } from "../src/cloudflare/telegram";
+
+function richMessageUpdate(updateId: number, title: string, edited = false): TelegramUpdate {
+  const message = {
+    message_id: 77,
+    date: 1_700_000_000,
+    ...(edited ? { edit_date: 1_700_000_100 } : {}),
+    chat: { id: -1001, title: "Channel", username: "xgeekshare", type: "channel" },
+    rich_message: {
+      blocks: [
+        { type: "heading", size: 1, text: { type: "bold", text: title } },
+        { type: "paragraph", text: "富文本正文 #Rich" },
+        {
+          type: "list",
+          items: [{ label: "•", blocks: [{ type: "paragraph", text: "列表正文" }] }],
+        },
+        {
+          type: "table",
+          cells: [[{ text: "项目", is_header: true }, { text: "状态", is_header: true }], [{ text: "归档" }, { text: "正常" }]],
+        },
+        {
+          type: "details",
+          summary: "更多信息",
+          blocks: [{ type: "paragraph", text: "折叠正文" }, { type: "paragraph", text: "第二段" }],
+        },
+        {
+          type: "collage",
+          blocks: [
+            {
+              type: "photo",
+              photo: [{ file_id: "rich-photo", file_unique_id: "rich-photo-unique", file_size: 100 }],
+              caption: { text: "图片说明" },
+            },
+            {
+              type: "document",
+              document: { file_id: "rich-document", file_unique_id: "rich-document-unique", file_size: 100, file_name: "guide.pdf", mime_type: "application/pdf" },
+              caption: { text: "文件说明" },
+            },
+          ],
+        },
+      ],
+    },
+  };
+  return edited
+    ? { update_id: updateId, edited_channel_post: message }
+    : { update_id: updateId, channel_post: message };
+}
 
 test("webhook claims first delivery, skips terminal and fresh duplicates, and retries failed updates", async () => {
   const { db, env } = createTestEnv();
@@ -44,6 +92,54 @@ test("webhook claims first delivery, skips terminal and fresh duplicates, and re
     { status: "success", error: null, attempt_count: 2 },
   );
   assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages WHERE telegram_message_id = 9"), 1);
+});
+
+test("rich channel posts persist searchable content and media while edits respect admin overrides", async (context) => {
+  const { db, env } = createTestEnv();
+  const telegram = telegramFetch();
+  context.mock.method(globalThis, "fetch", telegram.handler);
+
+  assert.equal((await deliver(env, richMessageUpdate(60, "富文本标题"))).response.status, 204);
+  const row = db.row<{ html: string; plain_text: string; media: string; media_archive_status: string }>(
+    "SELECT html, plain_text, media, media_archive_status FROM messages WHERE id = 'message77'",
+  );
+  assert.match(row.html, /tg-rich-heading-1/);
+  assert.match(row.plain_text, /^富文本标题\n富文本正文 #Rich/);
+  assert.equal(row.media_archive_status, "archived");
+  assert.deepEqual(
+    (JSON.parse(row.media) as Array<{ type: string; archiveStatus: string }>).map(({ type, archiveStatus }) => ({ type, archiveStatus })),
+    [{ type: "photo", archiveStatus: "archived" }, { type: "file", archiveStatus: "archived" }],
+  );
+  assert.deepEqual(
+    db.sqlite.prepare("SELECT tag FROM message_tags WHERE message_id = 'message77'").all().map((item) => ({ ...item })),
+    [{ tag: "rich" }],
+  );
+  assert.equal(db.scalar("SELECT COUNT(*) AS value FROM messages_fts WHERE messages_fts MATCH '\"富文本正文\"'"), 1);
+
+  const publicResponse = await handleApi(new Request("https://archive.example.com/api/messages/message77"), env);
+  const publicMessage = await publicResponse.json() as { title: string; text: string; plainText: string; mediaItems: unknown[] };
+  assert.equal(publicMessage.title, "富文本标题");
+  assert.match(publicMessage.plainText, /富文本正文 #Rich/);
+  assert.match(publicMessage.text, /<ul class="tg-rich-list">/);
+  assert.match(publicMessage.text, /tg-rich-table-scroll/);
+  assert.match(publicMessage.text, /<details>/);
+  assert.match(publicMessage.text, /tg-rich-block-break/);
+  assert.equal(publicMessage.mediaItems.length, 2);
+
+  const patch = await handleApi(
+    new Request("https://archive.example.com/api/admin/messages/message77", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Origin: "https://archive.example.com" },
+      body: JSON.stringify({ plainText: "管理正文" }),
+    }),
+    env,
+  );
+  assert.equal(patch.status, 200);
+  assert.equal((await deliver(env, richMessageUpdate(61, "Telegram 编辑标题", true))).response.status, 204);
+  assert.deepEqual(
+    db.row("SELECT html, plain_text, admin_override FROM messages WHERE id = 'message77'"),
+    { html: "管理正文", plain_text: "管理正文", admin_override: 1 },
+  );
 });
 
 test("stale processing is reclaimed with a conditional claim and only one concurrent replay wins", async () => {


### PR DESCRIPTION
## Summary

- Parse Telegram `message.rich_message.blocks` into the existing safe HTML and plain-text pipeline.
- Extract rich-message attachments into the existing R2/media flow while preserving captions in the body.
- Add responsive styles and coverage for rich blocks, sanitization, webhook persistence, edits, FTS, and multiple media.

## Verification

- `npm test` (62 passing)
- `npm run typecheck`
- `npm run lint`
- `npm run build`

No dependency, database migration, or public API changes.